### PR TITLE
Don't check identical files

### DIFF
--- a/main.py
+++ b/main.py
@@ -75,6 +75,13 @@ def apply_prompt_to_files(prompt: str, files: dict) -> dict:
         new_files[f] = new
 
     check_result(list_files(old_files), list_files(new_files), prompt)
+    old_files_filtered = {
+        k: v for k, v in old_files.items() if k in new_files and v != new_files[k]
+    }
+    new_files_filtered = {
+        k: v for k, v in new_files.items() if k in old_files and v != old_files[k]
+    }
+    check_result(list_files(old_files_filtered), list_files(new_files_filtered), prompt)
 
     return new_files
 


### PR DESCRIPTION
In apply_prompt_to_files, call check_result with modified old_files and new_files lists that remove unchanged key/value pairs from both lists.