### PR TITLE
Fix check_result calls

### DIFF
--- a/main.py
+++ b/main.py
@@ -65,12 +65,15 @@ def apply_prompt_to_files(prompt: str, files: dict) -> dict:
         new = format_python_code(apply_patch(f, old, patch))
         new_files[f] = new
 
-    check_result(list_files(old_files), list_files(new_files), prompt)
     old_files_filtered = {
-        k: v for k, v in old_files.items() if k in new_files and v != new_files[k]
+        k: v
+        for k, v in old_files.items()
+        if k in new_files and v != new_files[k] or k not in new_files
     }
     new_files_filtered = {
-        k: v for k, v in new_files.items() if k in old_files and v != old_files[k]
+        k: v
+        for k, v in new_files.items()
+        if k in old_files and v != old_files[k] or k not in old_files
     }
     check_result(list_files(old_files_filtered), list_files(new_files_filtered), prompt)
 


### PR DESCRIPTION
In apply_prompt_to_files, there are two calls to check_result, one with all files, and one with filtered files.

Remove the check of all files.

Additionally, the filtering logic is incorrect. 

A file should be kept in new_files if it has changed since old_files, OR if it's brand new. 

A file should be kept in old_files if it has changed since new_files, OR if new_files has removed it.