### PR TITLE
Call pytest after writing files

### DIFF
--- a/main.py
+++ b/main.py
@@ -93,9 +93,14 @@ def process_issue(issue: Issue) -> None:
     for k, v in updated_files.items():
         write_file(k, v)
 
+    import subprocess
+
+    result = subprocess.run(["pytest"], capture_output=True, text=True)
+    if result.returncode != 0:
+        raise Exception("Pytest failed")
+
     repo.commit_local_modifications(issue.title, f'Prompt: "{issue.description}"')
     repo.push_local_branch_to_origin(branch_id)
-
     if not repo.check_pull_request_title_exists("reitzensteinm/duopoly", issue.title):
         repo.create_pull_request(
             repo_name="reitzensteinm/duopoly",


### PR DESCRIPTION
In process_issue, call pytest after writing the updated files. Do this by executing it in a shell.

If pytest fails, throw an exception.