### PR TITLE
Make partition tests more succinct

### DIFF
--- a/test_utils.py
+++ b/test_utils.py
@@ -2,36 +2,33 @@ import pytest
 from utils import partition_by_predicate
 
 
-def test_partition_by_predicate_even():
-    assert partition_by_predicate([1, 2, 3, 4, 5, 6, 8, 10], lambda x: x % 2 == 0) == [
-        [1],
-        [2, 3],
-        [4, 5],
-        [6],
-        [8],
-        [10],
-    ]
+import pytest
+from utils import partition_by_predicate
 
 
-def test_partition_by_predicate_empty_list():
-    assert partition_by_predicate([], lambda x: x % 2 == 0) == []
-
-
-def test_partition_by_predicate_no_true_predicate():
-    assert partition_by_predicate([1, 3, 5, 7, 9], lambda x: x % 2 == 0) == [
-        [1, 3, 5, 7, 9]
-    ]
-
-
-def test_partition_by_predicate_all_true_predicate():
-    assert partition_by_predicate([2, 4, 6, 8, 10], lambda x: x % 2 == 0) == [
-        [2],
-        [4],
-        [6],
-        [8],
-        [10],
-    ]
-
-
-def test_partition_by_predicate_single_element():
-    assert partition_by_predicate([3], lambda x: x % 2 == 0) == [[3]]
+@pytest.mark.parametrize(
+    "input_list, expected",
+    [
+        (
+            [1, 2, 3, 4, 5, 6, 8, 10],
+            [[1], [2, 3], [4, 5], [6], [8], [10]],
+        ),
+        (
+            [],
+            [],
+        ),
+        (
+            [1, 3, 5, 7, 9],
+            [[1, 3, 5, 7, 9]],
+        ),
+        (
+            [2, 4, 6, 8, 10],
+            [[2], [4], [6], [8], [10]],
+        ),
+    ],
+)
+def test_partition_by_predicate(
+    input_list,
+    expected,
+):
+    assert partition_by_predicate(input_list, lambda x: x % 2 == 0) == expected


### PR DESCRIPTION
The partition_by_predicate tests are good, but much too long. Place them in a single function, and use pytest features as needed.