### PR TITLE
When pytest fails, include exception detail

### DIFF
--- a/main.py
+++ b/main.py
@@ -97,8 +97,7 @@ def process_issue(issue: Issue) -> None:
 
     result = subprocess.run(["pytest"], capture_output=True, text=True)
     if result.returncode != 0:
-        raise Exception("Pytest failed")
-
+        raise Exception("Pytest failed\n" + result.stderr)
     repo.commit_local_modifications(issue.title, f'Prompt: "{issue.description}"')
     repo.push_local_branch_to_origin(branch_id)
     if not repo.check_pull_request_title_exists("reitzensteinm/duopoly", issue.title):


### PR DESCRIPTION
When pytest fails, include its output in the exception that's thrown, so it will be printed later.