### PR TITLE
No output from pytest

### DIFF
--- a/main.py
+++ b/main.py
@@ -95,7 +95,7 @@ def process_issue(issue: Issue) -> None:
 
     import subprocess
 
-    result = subprocess.run(["pytest"], capture_output=True, text=True)
+    result = subprocess.run(["pytest", "-ra"], capture_output=True, text=True)
     if result.returncode != 0:
         raise Exception("Pytest failed\n" + result.stderr)
     repo.commit_local_modifications(issue.title, f'Prompt: "{issue.description}"')


### PR DESCRIPTION
The call to pytest isn't returning any error information on stderr when a pytest test throws an exception. Please update the command line arguments so it does.