### PR TITLE
Fix duplicate main call in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -137,7 +137,3 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
     main(retries=args.retries)
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
The main function is called twice in main.py - once that propagates the retries count, and once that does not. Remove the old one which does not.