### PR TITLE
Add command.py

### DIFF
--- a/command.py
+++ b/command.py
@@ -1,0 +1,45 @@
+def command_to_str(command: dict) -> str:
+    formatted_command = f"@@{command['command']}@@"
+    if "response" in command:
+        formatted_command = f"> {formatted_command}"
+    for key, value in command.items():
+        if key not in ["command", "body", "response"]:
+            formatted_command += f" {key}={value}"
+    if "body" in command:
+        formatted_lines = "\n".join(
+            [f"> {line}" for line in command["body"].splitlines()]
+        )
+        formatted_command += f"\n{formatted_lines}"
+    return formatted_command
+
+
+def parse_command_string(command_string: str) -> list[dict]:
+    command_list = []
+    response_flag = False
+
+    for line in command_string.split("\n"):
+        if line.startswith("> @@"):
+            response_flag = True
+            line = line[2:].lstrip()
+
+        if line.startswith("@@") and line.endswith("@@"):
+            idx = line.index("@@", 2)
+            command_id = line[2:idx]
+
+            command_values = line[idx + 2 :].split(" ")
+            command_dict = {"command": command_id}
+
+            for item in command_values:
+                key, value = item.split("=")
+                command_dict[key] = value
+
+            command_list.append(command_dict)
+        elif line.startswith(">"):
+            body_line = line[1:].lstrip()
+            command_list[-1].setdefault("body", []).append(body_line)
+        else:
+            if not response_flag:
+                if command_list[-1].get("body"):
+                    command_list[-1]["body"] = "\n".join(command_list[-1]["body"])
+                command_list[-1]["response"] = line
+    return command_list


### PR DESCRIPTION
Add a new file, command.py. It is going to parse and pretty print commands.

It should have a function to turn a command into a printed string. It should have a function to parse a string, which returns an *array of commands*, as there may be multiple. The parse function does not need to support commands with responses.

Commands in Python are stored as dicts. The "command" key stores the id of the key. The optional "body" key stores the body of the command. The optional "response" key contains the other system's response to the command. All other keys are a key/value pair, which are all string/strings.

In text, the format of a command is as follows:

@@COMMAND_ID@@ key_a=value_a key_b=value_b
OPTIONAL
BODY
OVER
MULTIPLE
LINES

If the command has a response, it should be printed with the command quoted forum style, with the response below:

> @@COMMAND_ID@@ key_a=value_a key_b=value_b
> OPTIONAL
> BODY
> OVER
> MULTIPLE
> LINES
RESPONSE LINE A
RESPONSE LINE B