### PR TITLE
Fix command bug

### DIFF
--- a/command.py
+++ b/command.py
@@ -29,7 +29,7 @@ def parse_command_string(command_string: str) -> list[dict]:
     command_list = []
 
     for line in command_string.split("\n"):
-        if line.startswith("@@") and line.endswith("@@"):
+        if line.startswith("@@"):
             idx = line.index("@@", 2)
             command_id = line[2:idx]
 


### PR DESCRIPTION
In command.py, parse_command_string is looking for lines that end with @@, which commands don't necessarily do if they have keys and values attached.