### PR TITLE
Fix Command Bug II

### DIFF
--- a/command.py
+++ b/command.py
@@ -37,8 +37,9 @@ def parse_command_string(command_string: str) -> list[dict]:
             command_dict = {"command": command_id}
 
             for item in command_values:
-                key, value = item.split("=")
-                command_dict[key] = value
+                if item:  # Ignore empty string
+                    key, value = item.split("=")
+                    command_dict[key] = value
 
             command_list.append(command_dict)
         else:


### PR DESCRIPTION
In parse_command_string, the first element of command_values can be an empty string, which fails to parse. Please ignore it.