### PR TITLE
Use forward slashes for all file paths

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ def find_python_files() -> list[str]:
     for root, dirnames, filenames in os.walk("."):
         for filename in fnmatch.filter(filenames, "*.py"):
             if "venv" not in root:
-                python_files.append(os.path.join(root, filename))
+                python_files.append(f"{root}/{filename}")
 
     return python_files
 


### PR DESCRIPTION
In find_python_files in main.py, replace Windows style backslashes with universal forward slashes in any paths discovered.