### PR TITLE
Add model selection to gpt_query

### DIFF
--- a/gpt.py
+++ b/gpt.py
@@ -70,11 +70,14 @@ from cache import memoize
 
 
 @memoize
-def gpt_query(message: str, system: str = SYSTEM_PATCH) -> str:
+def gpt_query(message: str, system: str = SYSTEM_PATCH, model: str = "gpt-4") -> str:
+    if model not in ["gpt-4", "gpt-3.5-turbo"]:
+        raise ValueError("Invalid model specified. Must be 'gpt-4' or 'gpt-3.5-turbo'.")
+
     openai.api_key = os.environ["OPENAI_API_KEY"]
 
     completion = openai.ChatCompletion.create(
-        model="gpt-4",
+        model=model,
         messages=[
             {
                 "role": "system",


### PR DESCRIPTION
Add a parameter to gpt_query in gpt.py to enable the caller to specify a model. The default should be "gpt-4", but "gpt-3.5-turbo" should be usable as well. Add type checking to make sure it's (for now) one of these two models.