### PR TITLE
Add tool to list imports

### DIFF
--- a/src/tools/imports.py
+++ b/src/tools/imports.py
@@ -1,0 +1,10 @@
+from gpt import gpt_query
+
+SYSTEM_IMPORTS = """
+Extract any imports from the following source code, returning only the lines that import other files.
+"""
+
+
+def imports(source_code: str) -> str:
+    result = gpt_query(source_code, system=SYSTEM_IMPORTS, model="gpt-3.5-turbo")
+    return result


### PR DESCRIPTION
Add a tools/imports.py tool, which uses GPT 3.5 Turbo to take a Python file and return a list of imports, similar in structure to tools/summarize.py.

The prompt should be:

Extract any imports from the following source code, returning only the lines that import other files.