### PR TITLE
Move merge_approved_pr call

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -159,9 +159,9 @@ def merge_approved_prs() -> None:
 
 
 def main(retries=3, dry_run=False) -> None:
-    if not dry_run:
-        merge_approved_prs()
     for issue in fetch_open_issues("reitzensteinm/duopoly"):
+        if not dry_run:
+            merge_approved_prs()
         retry_count = 0
         while retry_count < retries:
             cprint(f"Attempt {retry_count + 1}", "magenta")


### PR DESCRIPTION
In main.py's main function, move the merge_approved_pr call so it is executed at the start of the loop.