### PR TITLE
Add synchronized decorator

### DIFF
--- a/utils/threading.py
+++ b/utils/threading.py
@@ -1,0 +1,11 @@
+import threading
+
+_lock = threading.RLock()
+
+
+def synchronized(func):
+    def _synchronized(*args, **kwargs):
+        with _lock:
+            return func(*args, **kwargs)
+
+    return _synchronized


### PR DESCRIPTION
Create a file utils/threading.py containing a synchronized function that can be used as a decorator. 

The decorator should wrap a function, acquiring a lock when the function is called, and releasing it after it has finished. The lock should be global and re-enterant. 