### PR TITLE
Make imports tool only work on Python code

### DIFF
--- a/src/gpt.py
+++ b/src/gpt.py
@@ -75,7 +75,7 @@ Think out loud about what you're about to do:
 <thinking line 2>
 
 List imports contained in a file:
-@@IMPORTS@@ path=<file>
+@@IMPORTS@@ path=<file> (Note: This tool works only on Python files)
 """
 
 from cache import memoize

--- a/src/tools/imports.py
+++ b/src/tools/imports.py
@@ -6,5 +6,8 @@ Extract any imports from the following source code, returning only the lines tha
 
 
 def imports(source_code: str) -> str:
+    if not source_code.strip().endswith(".py"):
+        return ""
+
     result = gpt_query(source_code, system=SYSTEM_IMPORTS, model="gpt-3.5-turbo")
     return result


### PR DESCRIPTION
The imports tool in imports.py should only work on Python code. Return an empty string for non-Python files. Additionally, update the instructions in gpt.py to reflect this.