### PR TITLE
Fix imports bug

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -84,8 +84,9 @@ def command_loop(prompt: str, files: dict) -> dict:
                     del new_files[c["path"]]
             elif comm == "IMPORTS":
                 file_contents = files.get(c["path"], "")
-                imports_result = imports(file_contents)
-                scratch += f"```python\n{imports_result}\n```\n"
+                if c["path"].endswith(".py"):
+                    imports_result = imports(file_contents)
+                    scratch += f"```python\n{imports_result}\n```\n"
             elif comm == "FINISH":
                 return new_files
 

--- a/src/tools/imports.py
+++ b/src/tools/imports.py
@@ -6,8 +6,5 @@ Extract any imports from the following source code, returning only the lines tha
 
 
 def imports(source_code: str) -> str:
-    if not source_code.strip().endswith(".py"):
-        return ""
-
     result = gpt_query(source_code, system=SYSTEM_IMPORTS, model="gpt-3.5-turbo")
     return result


### PR DESCRIPTION
The imports.py tool checks if the argument ends with ".py" to check if the source code is python - but this is the source code of the file, not the filename. 

Remove this check from the imports tool, and instead place it where it's called, in main.py.