### PR TITLE
Ignore target with pytest

### DIFF
--- a/src/pipeline/issue.py
+++ b/src/pipeline/issue.py
@@ -132,7 +132,7 @@ def process_issue(issue: Issue, dry_run: bool) -> None:
         os.remove(f)
 
     result = subprocess.run(
-        ["pytest", "-rf"],
+        ["pytest", "--ignore", target_dir, "-rf"],
         capture_output=True,
         text=True,
     )


### PR DESCRIPTION
In process_issue in issue.py, ignore the target directory when calling Pytest.