### PR TITLE
Remove branch reset logic

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -18,16 +18,13 @@ def merge_approved_prs() -> None:
 def main(dry_run=False) -> None:
     if not dry_run:
         merge_approved_prs()
-        
+
     for issue in repo.fetch_open_issues("reitzensteinm/duopoly"):
         try:
             process_issue(issue, dry_run)
         except Exception as e:
             cprint(f"{str(e)}\n{traceback.format_exc()}", "red")
             print(f"Failed to process issue {issue.id}")
-
-        if not dry_run:
-            repo.switch_and_reset_branch("main")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In main.py, remove the repo.switch_and_reset_branch call at the end of main.