### PR TITLE
Run PyLint in addition to PyTest

### DIFF
--- a/src/pipeline/issue.py
+++ b/src/pipeline/issue.py
@@ -134,6 +134,14 @@ def process_issue(issue: Issue, dry_run: bool) -> None:
     for f in deleted_files:
         os.remove(f)
 
+    pylint_result = subprocess.run(
+        ["pylint", "--disable=R,C,W", os.path.join(target_dir, "src"), "--exit-zero"],
+        capture_output=True,
+        text=True,
+    )
+    if pylint_result.returncode != 0:
+        raise Exception("Pylint failed\n" + pylint_result.stdout)
+
     result = subprocess.run(
         ["pytest", os.path.join(target_dir, "src"), "-rf"],
         capture_output=True,


### PR DESCRIPTION
Run PyLint in addition to PyTest in process_issue in main.py using the same directory.

Run it in error mode only, by passing in the flags --disable=R,C,W.

If the exit code is not 0, throw an exception containing the stdout of pylint.