### PR TITLE
Add sleep after merging PR

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,6 @@
 import argparse
 import traceback
+import time
 from concurrent.futures import ThreadPoolExecutor
 from termcolor import cprint
 from pipeline.issue import process_issue
@@ -11,6 +12,7 @@ def merge_approved_prs() -> None:
     for pr_id in approved_prs:
         if repo.merge_with_rebase_if_possible("reitzensteinm/duopoly", pr_id):
             print(f"Merged PR: {pr_id}")
+            time.sleep(10)
         else:
             print(f"Could not merge PR: {pr_id}")
     repo.fetch_new_changes()


### PR DESCRIPTION
In merge_approved_prs in main.py, add a 10 second sleep after successfully merging a PR.