### PR TITLE
Load prompts YAML in evals

### DIFF
--- a/src/evals/evals.py
+++ b/src/evals/evals.py
@@ -1,2 +1,15 @@
+from dataclasses import dataclass
+from typing import List
+import yaml
+
+
+@dataclass
+class Eval:
+    prompt: str
+    tests: List[str]
+
+
 def process_evals(directory: str):
-    pass
+    with open(f"{directory}/prompts.yaml", "r") as file:
+        data = yaml.safe_load(file)
+        evals = [Eval(prompt=key, tests=value["tests"]) for key, value in data.items()]


### PR DESCRIPTION
In process_evals, use PyYAML to load the prompts.yaml file in the directory passed in.

Create an Eval dataclass, which contains a prompt string, and a tests string array. Read an array of Evals from the prompts.yaml file.

This is an example of the file format:

```basic:
  prompt: "In main.py, rename the main function to main2"
  tests: [ "test_main_rename" ]
ambiguous_file:
  prompt: "Rename the main function to main2"
  tests: [ "test_main_rename" ]
short:
  prompt: "Rename the main to main2"
  tests: [ "test_main_rename" ]```