### PR TITLE
Throw exception on command loop limit

### DIFF
--- a/src/pipeline/issue.py
+++ b/src/pipeline/issue.py
@@ -82,6 +82,7 @@ def command_loop(prompt: str, files: dict) -> dict:
                     scratch += f"```python\n{imports_result}\n```\n"
             elif comm == "FINISH":
                 return new_files
+    raise Exception("Command Loop Overflow")
 
 
 def apply_prompt_to_files(prompt: str, files: dict) -> dict:


### PR DESCRIPTION
In the command_loop function in issue.py, if the function isn't returned before the loop is over, throw an exception "Command Loop Overflow".