### PR TITLE
Add trace rendering

### DIFF
--- a/src/tracing/render.py
+++ b/src/tracing/render.py
@@ -1,0 +1,38 @@
+import jinja2
+from src.tracing.trace import Trace
+
+TAG_COLOR_MAPPING = {
+    # Add tag to color mapping here
+    # Format: 'tag': {'background': 'color', 'border': 'color', 'text': 'color'}
+}
+
+
+def render_trace(trace: Trace) -> str:
+    template = jinja2.Template(
+        """
+		<html>
+		<head>
+			<style>
+				.panel {
+					padding: 10px;
+				}
+				{% for tag, colors in tag_color_mapping.items() %}
+				.bg-{{ tag }} {
+					background-color: {{ colors['background'] }};
+					border-color: {{ colors['border'] }};
+					color: {{ colors['text'] }};
+				}
+				{% endfor %}
+			</style>
+		</head>
+		<body>
+			{% for trace_item in trace_items %}
+				<div class="panel bg-{{ trace_item.tag }}">
+					{{ trace_item.text }}
+				</div>
+			{% endfor %}
+		</body>
+		</html>
+	"""
+    )
+    return template.render(trace_items=trace.items, tag_color_mapping=TAG_COLOR_MAPPING)


### PR DESCRIPTION
Add a render.py file to the tracing directory.

It should have a function, render_trace, which takes a Trace from trace.py, and outputs a string.

The return value should be HTML, rendered with the jinja2 library. It should show the text of the trace in panels going down the page. The background, border and text colours of the panels should be configurable based on tag type.

The tag to colour mapping should be in a constant dict in the file.