### PR TITLE
Add default trace colours

### DIFF
--- a/src/tracing/render.py
+++ b/src/tracing/render.py
@@ -1,6 +1,7 @@
 import jinja2
 
 TAG_COLOR_MAPPING = {
+    "default": {"background": "white", "border": "black", "text": "black"},
     # Add tag to color mapping here
     # Format: 'tag': {'background': 'color', 'border': 'color', 'text': 'color'}
 }


### PR DESCRIPTION
In trace.py, add a default colour scheme that will be used if the tag isn't found. It should have a white background, black text, and black border.