### PR TITLE
Add traces around program

### DIFF
--- a/src/gpt.py
+++ b/src/gpt.py
@@ -3,6 +3,7 @@ import openai
 import time
 from utils import read_file, write_file, partition_by_predicate
 from termcolor import cprint
+from tracing.trace import get_trace
 
 SYSTEM_PATCH = "You are a helpful programming assistant. \
                 You will be given code as well as instructions to modify it. \
@@ -100,6 +101,9 @@ def gpt_query(message: str, system: str = SYSTEM_PATCH, model: str = "gpt-4") ->
         try:
             start_time = time.time()
             cprint(f"GPT Input: {message}", "blue")
+            trace = get_trace()
+            if trace is not None:
+                trace.add_trace_data("gpt_in", f"GPT Input: {message}")
             completion = openai.ChatCompletion.create(
                 model=model,
                 messages=[
@@ -131,5 +135,8 @@ def gpt_query(message: str, system: str = SYSTEM_PATCH, model: str = "gpt-4") ->
     content = completion.choices[0].message.content
 
     cprint(f"GPT Output: {content}", "cyan")
+    trace = get_trace()
+    if trace is not None:
+        trace.add_trace_data("gpt_out", f"GPT Output: {content}")
 
     return content

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,7 @@ from termcolor import cprint
 from pipeline.issue import process_issue
 import repo
 from evals.evals import process_evals
-from tracing.trace import create_trace, bind_trace
+from tracing.trace import create_trace, bind_trace, get_trace
 
 
 def merge_approved_prs() -> None:
@@ -32,6 +32,9 @@ def main(dry_run=False) -> None:
         try:
             process_issue(issue, dry_run)
         except Exception as e:
+            trace = get_trace()
+            if trace is not None:
+                trace.add_trace_data("exception", f"{str(e)}\n{traceback.format_exc()}")
             cprint(f"{str(e)}\n{traceback.format_exc()}", "red")
             print(f"Failed to process issue {issue.id}")
 

--- a/src/pipeline/issue.py
+++ b/src/pipeline/issue.py
@@ -10,6 +10,7 @@ import command
 import repo
 import shutil
 from repo import Issue
+from tracing.trace import get_trace
 
 
 def format_python_code(code: str) -> str:
@@ -123,7 +124,7 @@ def process_issue(issue: Issue, dry_run: bool) -> None:
     if os.path.exists(target_dir):
         shutil.rmtree(target_dir)
     os.makedirs(target_dir, exist_ok=True)
-    repo.clone_repository("https://github.com/reitzensteinm/duopoly.git", target_dir)
+    repo.clone_repository("reitzensteinm/duopoly", target_dir)
 
     branch_id = f"issue-{issue.id}"
 
@@ -149,6 +150,9 @@ def process_issue(issue: Issue, dry_run: bool) -> None:
         capture_output=True,
         text=True,
     )
+    trace = get_trace()
+    if trace is not None:
+        trace.add_trace_data("pylint", pylint_result.stdout)
     print(pylint_result.stdout)
     if pylint_result.returncode != 0:
         raise Exception("Pylint failed\n" + pylint_result.stdout)


### PR DESCRIPTION
Use get_trace in trace.py to grab a trace to add a tag and trace to.

Use this to add traces in the following places:

In gpt.py, trace the GPT input as gpt_in, and the GPT output as gpt_out.

In issue.py, trace the pylint_result as pylint.

In main.py's process_open_issue, trace any exception result as exception.