### PR TITLE
Use model constants in tools

### DIFF
--- a/src/tools/imports.py
+++ b/src/tools/imports.py
@@ -1,4 +1,4 @@
-from gpt import gpt_query
+from gpt import gpt_query, GPT_3_5
 
 SYSTEM_IMPORTS = """
 Extract any imports from the following source code, returning only the lines that import other files.
@@ -6,5 +6,5 @@ Extract any imports from the following source code, returning only the lines tha
 
 
 def imports(source_code: str) -> str:
-    result = gpt_query(source_code, system=SYSTEM_IMPORTS, model="gpt-3.5-turbo")
+    result = gpt_query(source_code, system=SYSTEM_IMPORTS, model=GPT_3_5)
     return result

--- a/src/tools/summarize.py
+++ b/src/tools/summarize.py
@@ -1,4 +1,4 @@
-from gpt import gpt_query
+from gpt import gpt_query, GPT_3_5
 
 SYSTEM_SUMMARIZE = """
 Summarize the following source code, extracting classes, functions and constants by extracting the definitions into the following format:
@@ -13,5 +13,5 @@ CONSTANT
 
 
 def summarize(source_code: str) -> str:
-    result = gpt_query(source_code, system=SYSTEM_SUMMARIZE, model="gpt-3.5-turbo")
+    result = gpt_query(source_code, system=SYSTEM_SUMMARIZE, model=GPT_3_5)
     return result


### PR DESCRIPTION
In the tools files which call GPT, use the new model constants in gpt.py instead of naming the model string directly.