### PR TITLE
Remove exit zero flag from pylint

### DIFF
--- a/src/pipeline/issue.py
+++ b/src/pipeline/issue.py
@@ -145,7 +145,7 @@ def process_issue(issue: Issue, dry_run: bool) -> None:
         os.remove(f)
 
     pylint_result = subprocess.run(
-        ["pylint", "--disable=R,C,W", os.path.join(target_dir, "src"), "--exit-zero"],
+        ["pylint", "--disable=R,C,W", os.path.join(target_dir, "src")],
         capture_output=True,
         text=True,
     )


### PR DESCRIPTION
When calling pylint in issue.py, don't pass the exit zero flag to it.