### PR TITLE
Fix system check prompt

### DIFF
--- a/src/gpt.py
+++ b/src/gpt.py
@@ -28,7 +28,8 @@ SYSTEM_CHECK = "You are a helpful programming assistant. \
                 Please write a paragraph explaining your reasoning using this format: 'REASONING: <reasoning>'. \
                 Afterwards, give a verdict, either by saying 'VERDICT: OK' or 'VERDICT: ERROR'. \
                 This should be the last line of your response. \
-                Are you absolutely sure? If you have any doubt at all, tell me there is an error."
+                Are you absolutely sure? If you have any doubt at all, tell me there is an error. \
+                If files aren't supplied, you can assume that their contents are correct. You are only checking issues in what you can see."
 
 SYSTEM_COMMAND = """
 You are a helpful programming assistant. You will be given a list of files as well as instructions to modify them.


### PR DESCRIPTION
In the SYSTEM_CHECK prompt in gpt.py, at the end, add this instruction:

"If files aren't supplied, you can assume that their contents is correct. You are only checking issues in what you can see."