### PR TITLE
Fix bug in synchronize_files

### DIFF
--- a/src/pipeline/issue.py
+++ b/src/pipeline/issue.py
@@ -51,7 +51,7 @@ def synchronize_files(target_dir, old_files, updated_files):
 
     deleted_files = [f for f in old_files.keys() if f not in updated_files]
     for f in deleted_files:
-        os.remove(f)
+        os.remove(os.path.join(target_dir, f))
 
 
 def command_loop(prompt: str, files: dict) -> dict:


### PR DESCRIPTION
Fix bug in synchronize_files in issue.py. It calculates the path for writing files correctly, but doesn't do this when deleting files. It should also be relative to the target directory.