### PR TITLE
Run pytest in process_eval

### DIFF
--- a/src/evals/evals.py
+++ b/src/evals/evals.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import List
 import yaml
+import subprocess
 
 
 @dataclass
@@ -13,3 +14,14 @@ def process_evals(directory: str):
     with open(f"{directory}/prompts.yaml", "r") as file:
         data = yaml.safe_load(file)
         evals = [Eval(prompt=key, tests=value["tests"]) for key, value in data.items()]
+
+    for eval in evals:
+        test_names = " ".join(eval.tests)
+        result = subprocess.run(
+            ["pytest", f"{directory}/src", "-k", test_names],
+            capture_output=True,
+            text=True,
+        )
+
+        if result.returncode != 0:
+            raise Exception(f"Pytest failed for tests: {test_names}\n{result.stderr}")


### PR DESCRIPTION
In process_evals in evals.py, run pytest in the supplied directory. Specify that only the functions in the array specified are called. Throw an exception is pytest fails.