### PR TITLE
Add run_tests switch to process_directory

### DIFF
--- a/src/evals/evals.py
+++ b/src/evals/evals.py
@@ -10,18 +10,21 @@ class Eval:
     tests: List[str]
 
 
-def process_evals(directory: str):
+def process_evals(directory: str, should_run_tests: bool = True):
     with open(f"{directory}/prompts.yaml", "r") as file:
         data = yaml.safe_load(file)
         evals = [Eval(prompt=key, tests=value["tests"]) for key, value in data.items()]
 
-    for eval in evals:
-        test_names = " ".join(eval.tests)
-        result = subprocess.run(
-            ["pytest", f"{directory}/src", "-k", test_names],
-            capture_output=True,
-            text=True,
-        )
+    if should_run_tests:
+        for eval in evals:
+            test_names = " ".join(eval.tests)
+            result = subprocess.run(
+                ["pytest", f"{directory}/src", "-k", test_names],
+                capture_output=True,
+                text=True,
+            )
 
-        if result.returncode != 0:
-            raise Exception(f"Pytest failed for tests: {test_names}\n{result.stderr}")
+            if result.returncode != 0:
+                raise Exception(
+                    f"Pytest failed for tests: {test_names}\n{result.stderr}"
+                )


### PR DESCRIPTION
In process_directory in issue.py, add a switch to configure whether to run tests. In evals.py, when calling process_directory, pass this flag in to not run the tests.