### PR TITLE
Add schema for commands

### DIFF
--- a/src/commands/command.py
+++ b/src/commands/command.py
@@ -1,61 +1,137 @@
+"""
+Example Command schema:
+{
+    "name": "get_current_weather",
+    "description": "Get the current weather in a given location",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "location": {
+                "type": "string",
+                "description": "The city and state, e.g. San Francisco, CA",
+            },
+            "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+        },
+        "required": ["location"],
+    }
+}
+"""
+
+
 class Command:
-    name = ""
+    """
+    Class representing a command.
+    """
+
+    name: str = ""
 
     def __init__(self):
         pass
 
     @staticmethod
-    def schema():
+    def schema() -> dict:
+        """
+        Returns the schema for the command.
+        """
         return {}
 
     @staticmethod
-    def load_from_json(json_data):
+    def load_from_json(json_data: dict):
+        """
+        Loads the command from the provided json_data.
+        """
         pass
 
     def execute(self):
+        """
+        Executes the command.
+        """
         pass
 
 
 class Think(Command):
-    name = "Think"
+    """
+    Class representing a Think command.
+    """
 
-    def __init__(self, thought):
-        self.thought = thought
+    name: str = "Think"
+
+    def __init__(self, thought: str):
+        self.thought: str = thought
 
     @staticmethod
-    def schema():
+    def schema() -> dict:
+        """
+        Returns the schema for the Think command.
+        """
         return {
-            "thought": str,
+            "type": "object",
+            "properties": {
+                "thought": {
+                    "type": "string",
+                    "description": "A description of what you plan to do in your next steps",
+                }
+            },
+            "required": ["thought"],
         }
 
     @staticmethod
-    def load_from_json(json_data):
+    def load_from_json(json_data: dict) -> "Think":
+        """
+        Loads the Think command from the provided json_data.
+        """
         return Think(json_data["thought"])
 
-    def execute(self):
+    def execute(self) -> str:
+        """
+        Executes the Think command.
+        """
         return self.thought
 
 
 class Verdict(Command):
-    name = "Verdict"
+    """
+    Class representing a Verdict command.
+    """
 
-    def __init__(self, reasoning, verdict):
-        self.reasoning = reasoning
-        self.pass_verdict = verdict
+    name: str = "Verdict"
+
+    def __init__(self, reasoning: str, verdict: bool):
+        self.reasoning: str = reasoning
+        self.pass_verdict: bool = verdict
 
     @staticmethod
-    def schema():
+    def schema() -> dict:
+        """
+        Returns the schema for the Verdict command.
+        """
         return {
-            "reasoning": str,
-            "pass": bool,
+            "type": "object",
+            "properties": {
+                "reasoning": {
+                    "type": "string",
+                    "description": "Text that describes the reason for the supplied verdict",
+                },
+                "verdict": {
+                    "type": "boolean",
+                    "description": "A Boolean that describes whether or not the change is judged to be successful",
+                },
+            },
+            "required": ["reasoning", "verdict"],
         }
 
     @staticmethod
-    def load_from_json(json_data):
-        return Verdict(json_data["reasoning"], json_data["pass"])
+    def load_from_json(json_data: dict) -> "Verdict":
+        """
+        Loads the Verdict command from the provided json_data.
+        """
+        return Verdict(json_data["reasoning"], json_data["verdict"])
 
-    def execute(self):
+    def execute(self) -> tuple:
+        """
+        Executes the Verdict command.
+        """
         return self.reasoning, self.pass_verdict
 
 
-commands = [Think, Verdict]
+commands: list = [Think, Verdict]


### PR DESCRIPTION
In commands/command.py, add an example Command schema at the top in a comment:

{
    "name": "get_current_weather",
    "description": "Get the current weather in a given location",
    "parameters": {
        "type": "object",
        "properties": {
            "location": {
                "type": "string",
                "description": "The city and state, e.g. San Francisco, CA",
            },
            "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
        },
        "required": ["location"],
    }}


Update Think and Verdict in command.py to return a schema that is similar. 

For Think, thought should read: "A description of what you plan to do in your next steps"

For Verdict, reasoning should be "text that describes the reason for the supplied verdict". verdict should be a boolean that descibes whether or not the change is judged to be successful.

Add docstrings and types to the file reflecting the above information.

The old file in command.py is legacy, and unrelated to this file.