### PR TITLE
Add function to return GPT response into command

### DIFF
--- a/src/commands/command.py
+++ b/src/commands/command.py
@@ -151,3 +151,20 @@ def extract_schemas(command_classes):
     """
     schemas = [command_class.schema() for command_class in command_classes]
     return schemas
+
+
+def parse_gpt_response(command_classes, gpt_response):
+    """
+    Parses the response from GPT and returns a Command instance for that response.
+    """
+    # i.e. GPT response looks like:
+    # {
+    #   "arguments": "{\n\"reasoning\": \"Yes, the change is correct. The result of 1+1 is indeed 2. The expression has been simplified correctly.\",\n\"verdict\": true\n}",
+    #   "name": "Verdict"
+    # }
+
+    for command_class in command_classes:
+        if command_class.name == gpt_response["name"]:
+            return command_class.load_from_json(gpt_response["arguments"])
+
+    raise ValueError(f"Unrecognized command name: {gpt_response['name']}")


### PR DESCRIPTION
In commands/command.py, add a function that takes in a list of Command classes and a response form GPT, parses the response from GPT, and returns a Command instance for that response. An example of a response looks like this Python dict:

(Keep this dict as a comment)

{
  "arguments": "{\n\"reasoning\": \"Yes, the change is correct. The result of 1+1 is indeed 2. The expression has been simplified correctly.\",\n\"verdict\": true\n}",
  "name": "Verdict"
}