### PR TITLE
Create apply_prompt_to_files_new

### DIFF
--- a/src/pipeline/issue.py
+++ b/src/pipeline/issue.py
@@ -8,7 +8,14 @@ from gpt import SYSTEM_CHECK, SYSTEM_CHECK_FUNC, gpt_query
 import gpt
 from utils import read_file, write_file, add_line_numbers
 import command
-from commands.command import Think, Verdict  # Importing Think and Verdict
+from commands.command import (
+    Think,
+    Verdict,
+    Files,
+    ReplaceFile,
+    Search,
+    DeleteFile,
+)  # Importing all commands
 from commands.loop import command_loop_new  # Importing command_loop_new
 import repo
 import shutil
@@ -121,6 +128,37 @@ def apply_prompt_to_files(prompt: str, files: dict) -> dict:
         for k, v in new_files.items()
         if k in old_files and v != old_files[k] or k not in old_files
     }
+
+    check_result(
+        list_files(old_files_filtered),
+        list_files(new_files_filtered),
+        prompt,
+    )
+
+    return new_files
+
+
+def apply_prompt_to_files_new(prompt: str, files: dict) -> dict:
+    old_files = files
+    scratch = "Available files: " + ", ".join(files.keys()) + "\n"
+    new_files = command_loop_new(
+        scratch + f"{str(uuid.uuid4())}\n{prompt}",
+        gpt.SYSTEM_COMMAND_FUNC,
+        [Think, Verdict, Files, ReplaceFile, Search, DeleteFile],
+        files,
+    )
+
+    old_files_filtered = {
+        k: v
+        for k, v in old_files.items()
+        if k in new_files and v != new_files[k] or k not in new_files
+    }
+    new_files_filtered = {
+        k: v
+        for k, v in new_files.items()
+        if k in old_files and v != old_files[k] or k not in old_files
+    }
+
     check_result(
         list_files(old_files_filtered),
         list_files(new_files_filtered),


### PR DESCRIPTION
In issue.py, create apply_prompt_to_files_new, which copies the body of apply_prompt_to_files, with these changes:

A scratch variable is created, listing available files from the files dict, just as command_loop currently does.

new_files is now calculated by calling command_loop_new, with the prompt concatenated with scratch, the gpt.SYSTEM_COMMAND_FUNC system message, all commands from command/commands.py, and files as the arguments.