### PR TITLE
Escape Tabs

### DIFF
--- a/src/commands/loop.py
+++ b/src/commands/loop.py
@@ -36,6 +36,7 @@ def command_loop_new(prompt: str, system: str, command_classes: list, files: dic
             result = gpt_query(
                 prompt + "\n" + state.scratch, system, extract_schemas(command_classes)
             )
+            result["arguments"] = result["arguments"].replace("\t", "\\t")
             command = parse_gpt_response(command_classes, result)
 
             if command.terminal:


### PR DESCRIPTION
In command_loop_new in loop.py, before passing the result of gpt_query to parse_gpt_response, replace all tab characters in the string in the "arguments" field with the escaped version \t.