### PR TITLE
Fix up replace prompt

### DIFF
--- a/src/tools/replace_file.py
+++ b/src/tools/replace_file.py
@@ -3,18 +3,16 @@ import os
 from gpt import gpt_query, GPT_4
 
 SYSTEM_REPLACE = """
-You are a helpful programming assistant. You will be given a list of files as well as instructions to modify them.
-Please make ONLY the changes requested, and respond only with the changes in the format specified.
+You are a helpful programming assistant. You will be given a file as well as instructions to modify it. 
 
-Once you have made all modifications, always add a FINISH command at the end.
-
-Do not add markdown quotes around code in your responses.
-
-When finished, call the Verdict function and return to me the results.
-"""
+Requirements:
+1) Please make ONLY the changes requested.
+2) Reply only with the updated file. 
+3) Do not add markdown quotes around code in your responses. 
+3) Use tabs to indentation."""
 
 
-def modify_file(file, instructions, original_file):
+def modify_file(original_file, instructions):
     full_instructions = instructions + "\n" + original_file
     new_file = gpt_query(full_instructions, SYSTEM_REPLACE)
     return new_file


### PR DESCRIPTION
In replace_file.py, only one file parameter should be passed in, which is the original file.

The system replace system message should read:

"You are a helpful programming assistant. You will be given a file as well as instructions to modify it. 

Requirements:
1) Please make ONLY the changes requested.
2) Reply only with the updated file. 
3) Do not add markdown quotes around code in your responses. 
3) Use tabs to indentation."