### PR TITLE
Don't escape tabs

### DIFF
--- a/src/commands/loop.py
+++ b/src/commands/loop.py
@@ -38,7 +38,6 @@ def command_loop_new(prompt: str, system: str, command_classes: list, files: dic
             result = gpt_query(
                 prompt + "\n" + state.scratch, system, extract_schemas(command_classes)
             )
-            result["arguments"] = result["arguments"].replace("\t", "\\t")
             command = parse_gpt_response(command_classes, result)
 
             if command.terminal:


### PR DESCRIPTION
In loop.py, the arguments property on result has tabs replaced with their escaped equivalent. This is no longer necessary, please remove this.