### PR TITLE
Add Optional Context To Modify File

### DIFF
--- a/src/tools/replace_file.py
+++ b/src/tools/replace_file.py
@@ -24,8 +24,8 @@ Requirements:
 """
 
 
-def modify_file(original_file, instructions):
-    instructions = f"### INSTRUCTIONS ###\n{instructions}\n### ORIGINAL FILE ###\n{original_file}\n### THINKING ###"
+def modify_file(original_file, instructions, context=""):
+    instructions = f"### CONTEXT ###\n{context}\n### INSTRUCTIONS ###\n{instructions}\n### ORIGINAL FILE ###\n{original_file}\n### THINKING ###"
     thinking = gpt_query(instructions, SYSTEM_REPLACE_THINK)
     instructions = f"{instructions}\n{thinking}\n### NEW FILE ###"
     new_file = gpt_query(instructions, SYSTEM_REPLACE)


### PR DESCRIPTION
Add an optional context string (defaulting to empty string) to modify_file in replace_file.py. It should be added to the start of the instructions variable as 

### CONTEXT ### 
<context>