### PR TITLE
Pass Context to Modify File

### DIFF
--- a/src/commands/command.py
+++ b/src/commands/command.py
@@ -297,7 +297,9 @@ class ReplaceFile(Command):
         """
         Executes the ReplaceFile command.
         """
-        new_content = modify_file(state.files[self.filename], self.instructions)
+        new_content = modify_file(
+            state.files[self.filename], self.instructions, state.scratch
+        )
         if self.filename.endswith(".py"):  # Check if it's a Python file
             new_content = format_python_code(
                 new_content


### PR DESCRIPTION
In commands/command.py, when executing ReplaceFile, modify the call to modify_file to pass the state's scratch property as context.