### PR TITLE
Fix ReplaceFile with empty files

### DIFF
--- a/src/commands/command.py
+++ b/src/commands/command.py
@@ -9,19 +9,19 @@ from black import (
 """
 Example Command schema:
 {
-    "name": "get_current_weather",
-    "description": "Get the current weather in a given location",
-    "parameters": {
-        "type": "object",
-        "properties": {
-            "location": {
-                "type": "string",
-                "description": "The city and state, e.g. San Francisco, CA",
-            },
-            "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
-        },
-        "required": ["location"],
-    }
+	"name": "get_current_weather",
+	"description": "Get the current weather in a given location",
+	"parameters": {
+		"type": "object",
+		"properties": {
+			"location": {
+				"type": "string",
+				"description": "The city and state, e.g. San Francisco, CA",
+			},
+			"unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+		},
+		"required": ["location"],
+	}
 }
 """
 
@@ -298,7 +298,7 @@ class ReplaceFile(Command):
         Executes the ReplaceFile command.
         """
         new_content = modify_file(
-            state.files[self.filename], self.instructions, state.scratch
+            state.files.get(self.filename, ""), self.instructions, state.scratch
         )
         if self.filename.endswith(".py"):  # Check if it's a Python file
             new_content = format_python_code(


### PR DESCRIPTION
Fix ReplaceFile in commands/command.py so that it works even if state.files does not contain the filename given. Instead pass an empty string to modify_file.