### PR TITLE
Add instructions to not use line numbers to ReplaceFile

### DIFF
--- a/src/tools/replace_file.py
+++ b/src/tools/replace_file.py
@@ -22,6 +22,7 @@ Requirements:
 4) Use tabs for indentation.
 5) Do not add any tests unless specifically requested.
 6) Return the entire file without skipping anything or stopping before the end, no matter how long it is. 
+7) Do not include line numbers in your output.
 """
 
 


### PR DESCRIPTION
In the replace_file.py tool, add a requirement that states "Do not include line numbers in your output."