### PR TITLE
Fix PyTest tool path

### DIFF
--- a/src/tools/pytest.py
+++ b/src/tools/pytest.py
@@ -6,7 +6,7 @@ import shutil
 def run_pytest(target_dir):
     try:
         result = subprocess.run(
-            ["pytest", os.path.join(target_dir, "src"), "-rf"],
+            ["pytest", target_dir, "-rf"],
             capture_output=True,
             text=True,
         )


### PR DESCRIPTION
In tools/pytest.py, don't do any calculations to modify the path that's passed in to add src to it. Just leave it as it was.