### PR TITLE
Handle deleted files in apply_prompt_to_directory

### DIFF
--- a/src/pipeline/issue.py
+++ b/src/pipeline/issue.py
@@ -103,6 +103,7 @@ def apply_prompt_to_directory(prompt: str, target_dir: str) -> None:
     files = {
         f: read_file(os.path.join(target_dir, f))
         for f in repo.get_all_checked_in_files(target_dir)
+        if os.path.isfile(os.path.join(target_dir, f))
     }
     updated_files = apply_prompt_to_files(prompt, files)
     synchronize_files(target_dir, files, updated_files)


### PR DESCRIPTION
In apply_prompt_to_directory in issue.py, it's possible that a checked in file has been deleted. When reading the files into memory, if a file doesn't exist on disk, skip it.