### PR TITLE
Add Command to Install Package

### DIFF
--- a/src/commands/command_install_package.py
+++ b/src/commands/command_install_package.py
@@ -1,0 +1,57 @@
+from commands.command import Command
+from commands.state import State
+from tools.pip import install_package
+
+
+class InstallPackage(Command):
+    """
+    Class representing InstallPackage command.
+    """
+
+    @classmethod
+    def name(cls) -> str:
+        return "InstallPackage"
+
+    @property
+    def terminal(self):
+        return False
+
+    def __init__(self, tool: str):
+        self.tool: str = tool
+
+    @staticmethod
+    def schema() -> dict:
+        """
+        Returns the schema for the InstallPackage command.
+        """
+        return {
+            "name": "InstallPackage",
+            "description": "Install a tool using pip",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "tool": {
+                        "type": "string",
+                        "description": "Name of the tool to be installed",
+                    },
+                },
+                "required": ["tool"],
+            },
+        }
+
+    @staticmethod
+    def load_from_json(json_data: dict) -> "InstallPackage":
+        """
+        Loads the InstallPackage command from the provided json_data.
+        """
+        return InstallPackage(json_data["tool"])
+
+    def execute(self, state: State):
+        """
+        Executes the InstallPackage command.
+        """
+        install_package(self.tool)
+        return f"Tool {self.tool} has been installed."
+
+    def __str__(self):
+        return f"Function Called: {self.name()} tool={self.tool}"

--- a/src/commands/commands.py
+++ b/src/commands/commands.py
@@ -7,6 +7,15 @@ from .command_files import Files
 from .command_replace_file import ReplaceFile
 from .command_search import Search
 from .command_delete_file import DeleteFile
+from .command_install_package import InstallPackage
 
 COMMANDS_CHECK = [Think, Verdict]
-COMMANDS_GENERATE = [Think, Verdict, Files, ReplaceFile, Search, DeleteFile]
+COMMANDS_GENERATE = [
+    Think,
+    Verdict,
+    Files,
+    ReplaceFile,
+    Search,
+    DeleteFile,
+    InstallPackage,
+]


### PR DESCRIPTION
Add an InstallPackage command to commands/command_install_package.py.

Look in commands/replace_file.py for an example of an existing command.

It should take one parameter, which is the name of the tool to install, and it should call tools/pip.py to install the package.

Add the command to COMMANDS_GENERATE in commands/commands.py to make it available.