### PR TITLE
Fix bug in Trace Render

### DIFF
--- a/src/tracing/render.py
+++ b/src/tracing/render.py
@@ -35,4 +35,6 @@ def render_trace(trace) -> str:
 		</html>
 	"""
     )
-    return template.render(trace_items=trace.items, tag_color_mapping=TAG_COLOR_MAPPING)
+    return template.render(
+        trace_items=trace.trace_data, tag_color_mapping=TAG_COLOR_MAPPING
+    )


### PR DESCRIPTION
Fix a bug in tracing/render.py, where render_trace takes a Trace objecct, but accesses trace.items instead of trace.trace_data