### PR TITLE
Fix render bug in Trace

### DIFF
--- a/src/tracing/render.py
+++ b/src/tracing/render.py
@@ -28,7 +28,7 @@ def render_trace(trace) -> str:
 		<body>
 			{% for trace_item in trace_items %}
 				<div class="panel bg-{{ trace_item.tag }}">
-					{{ trace_item.text }}
+					{{ trace_item.trace }}
 				</div>
 			{% endfor %}
 		</body>


### PR DESCRIPTION
In tracing/render.py, the text property of trace_item should instead be "trace"