### PR TITLE
Add Move File Tool

### DIFF
--- a/src/tools/move_file.py
+++ b/src/tools/move_file.py
@@ -1,0 +1,15 @@
+import copy
+
+
+def move_file(file_mapping, old_path, new_path):
+    # Creating a copy of the dictionary
+    file_mapping_copy = copy.deepcopy(file_mapping)
+
+    if old_path in file_mapping_copy:
+        # Moving the file to the new path
+        file_mapping_copy[new_path] = file_mapping_copy[old_path]
+        del file_mapping_copy[old_path]
+    else:
+        raise Exception(f"No such file: '{old_path}'")
+
+    return file_mapping_copy


### PR DESCRIPTION
Add a move file tool in tools/move_file.py. 

It should contain a function, move_file, that takes a dictionary mapping of file path strings to file content strings, a name for the old path of a file, and the name of a new path for a file.

The function should create a copy of the dictionary, called new_files. In this dictionary, move the file from the old path to the new path.

Return the dictionary.