### PR TITLE
Return dummy trace

### DIFF
--- a/src/tracing/trace.py
+++ b/src/tracing/trace.py
@@ -40,7 +40,7 @@ def bind_trace(trace: Trace):
 
 
 def get_trace() -> Trace:
-    return getattr(_thread_local, "trace", None)
+    return getattr(_thread_local, "trace", Trace("New Trace"))
 
 
 class TraceNotFound(Exception):


### PR DESCRIPTION
In trace.py's get_trace(), if a trace isn't found in a thread local variable, just return a new Trace object.