### PR TITLE
Change Trace Formatting

### DIFF
--- a/src/tracing/render.py
+++ b/src/tracing/render.py
@@ -28,12 +28,12 @@ def render_trace(trace) -> str:
 		<body>
 			{% for trace_item in trace_items %}
 				<div class="panel bg-{{ trace_item.tag }}">
-					{{ trace_item.trace }}
+					<pre>{{ trace_item.trace }}</pre>
 				</div>
 			{% endfor %}
 		</body>
 		</html>
-	"""
+		"""
     )
     return template.render(
         trace_items=trace.trace_data, tag_color_mapping=TAG_COLOR_MAPPING

--- a/src/tracing/tags.py
+++ b/src/tracing/tags.py
@@ -1,0 +1,3 @@
+GPT_INPUT = "gpt-input"
+GPT_OUTPUT = "gpt-output"
+EXCEPTION = "exception"


### PR DESCRIPTION
In tracing/render.py, style the text in the code blocks so that they format whitespace properly so they're appropriate for displaying code. 

Also, add a tracing/tags.py, which contains a list of constants:

GPT_INPUT = "gpt-input"
GPT_OUTPUT = "gpt-output"
EXCEPTION = "exception"