### PR TITLE
Return requirements.txt in install_package

### DIFF
--- a/src/commands/command_install_package.py
+++ b/src/commands/command_install_package.py
@@ -50,7 +50,10 @@ class InstallPackage(Command):
         """
         Executes the InstallPackage command.
         """
-        install_package(self.tool)
+        requirements_contents = install_package(self.tool)
+
+        state.new_files["requirements.txt"] = requirements_contents
+
         return f"Tool {self.tool} has been installed."
 
     def __str__(self):

--- a/src/tools/pip.py
+++ b/src/tools/pip.py
@@ -21,4 +21,8 @@ def install_package(package_name):
         except Exception as err:
             print("Failed to freeze requirements using pip.")
             return False
-    return True
+
+    with open("requirements.txt", "r") as file:
+        contents = file.read()
+
+    return contents


### PR DESCRIPTION
At the end of the install_package function, load requirements.txt off the disk and return it as a string.

Where this is called in command_install_package, modify the state file's new_files to update requirements.txt