### PR TITLE
Add trace colors

### DIFF
--- a/src/tracing/render.py
+++ b/src/tracing/render.py
@@ -2,6 +2,9 @@ import jinja2
 
 TAG_COLOR_MAPPING = {
     "default": {"background": "white", "border": "black", "text": "black"},
+    "gpt-input": {"background": "#000000", "border": "#808080", "text": "#00008B"},
+    "gpt-output": {"background": "#000000", "border": "#808080", "text": "#ADD8E6"},
+    "exception": {"background": "#000000", "border": "#FF0000", "text": "#FF0000"},
     # Add tag to color mapping here
     # Format: 'tag': {'background': 'color', 'border': 'color', 'text': 'color'}
 }


### PR DESCRIPTION
In tracing/render.py, add colours for the tags:

gpt-input: dark blue text on a black background with a grey border
gpt-output: light blue text on a black background with a grey border
exception: red text on a black background with a red border