### PR TITLE
Fix Install Package

### DIFF
--- a/src/commands/command_install_package.py
+++ b/src/commands/command_install_package.py
@@ -52,7 +52,7 @@ class InstallPackage(Command):
         """
         requirements_contents = install_package(self.tool)
 
-        state.new_files["requirements.txt"] = requirements_contents
+        state.files["requirements.txt"] = requirements_contents
 
         return f"Tool {self.tool} has been installed."
 


### PR DESCRIPTION
In command_install_package.py, the new_files property on State does not exist. Look in state.py to understand the property.