### PR TITLE
Add mypy tool

### DIFF
--- a/src/tools/mypy.py
+++ b/src/tools/mypy.py
@@ -1,0 +1,18 @@
+import subprocess
+from typing import Optional
+
+
+def run_mypy(target_dir: str, use_strict: bool) -> Optional[str]:
+    command = ["mypy", "--ignore-missing-imports"]
+
+    if use_strict:
+        command.append("--strict")
+
+    command.append(target_dir)
+
+    result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    if result.returncode == 0:
+        return None
+
+    return result.stderr.decode()


### PR DESCRIPTION
Add a tool to run mypy into tools/mypy.py. 

It should contain a function that runs mypy with --ignore-missing-imports on the specified target directory, and return the result as a string, or None if the type checking was successful.

The function parameters should be the target directory, as well as a bool for whether to use --strict.