### PR TITLE
Add margins around Trace renders

### DIFF
--- a/src/tracing/render.py
+++ b/src/tracing/render.py
@@ -18,6 +18,8 @@ def render_trace(trace) -> str:
 			<style>
 				.panel {
 					padding: 10px;
+					border: 8px solid black;
+					margin: 16px;
 				}
 				{% for tag, colors in tag_color_mapping.items() %}
 				.bg-{{ tag }} {


### PR DESCRIPTION
In tracing/render.py, add an 8px border and a 16px margin around each panel div.