### PR TITLE
Call pytest tool in Evals

### DIFF
--- a/src/evals/evals.py
+++ b/src/evals/evals.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import List
 import yaml
-import subprocess
+from tools.pytest import run_pytest
 
 
 @dataclass
@@ -17,11 +17,7 @@ def process_evals(directory: str):
 
     for eval in evals:
         test_names = " ".join(eval.tests)
-        result = subprocess.run(
-            ["pytest", f"{directory}/src", "-k", test_names],
-            capture_output=True,
-            text=True,
-        )
+        result = run_pytest(f"{directory}/src", test_names)
 
-        if result.returncode != 0:
-            raise Exception(f"Pytest failed for tests: {test_names}\n{result.stderr}")
+        if result is not None:
+            raise Exception(f"Pytest failed for tests: {test_names}\n{result}")

--- a/src/tools/pytest.py
+++ b/src/tools/pytest.py
@@ -3,10 +3,14 @@ import subprocess
 import shutil
 
 
-def run_pytest(target_dir):
+def run_pytest(target_dir, test_name=None):
     try:
+        command_list = ["pytest", target_dir, "-rf"]
+        if test_name is not None:
+            command_list = ["pytest", target_dir, "-k", test_name, "-rf"]
+
         result = subprocess.run(
-            ["pytest", target_dir, "-rf"],
+            command_list,
             capture_output=True,
             text=True,
         )


### PR DESCRIPTION
In evals.py, instead of running pytest on the command line, call the tool in pytest.py

Modify the pytest.py tool to support an optional specific test using the -k parameter, so the functionality remains the same.