### PR TITLE
Extract trace template

### DIFF
--- a/templates/tracing/trace.html
+++ b/templates/tracing/trace.html
@@ -1,0 +1,25 @@
+<html>
+	<head>
+		<style>
+			.panel {
+				padding: 10px;
+				border: 8px solid black;
+				margin: 16px;
+			}
+			{% for tag, colors in tag_color_mapping.items() %}
+			.bg-{{ tag }} {
+				background-color: {{ colors['background'] }};
+				border-color: {{ colors['border'] }};
+				color: {{ colors['text'] }};
+			}
+			{% endfor %}
+		</style>
+	</head>
+	<body>
+		{% for trace_item in trace_items %}
+			<div class="panel bg-{{ trace_item.tag }}">
+				<pre>{{ trace_item.trace }}</pre>
+			</div>
+		{% endfor %}
+	</body>
+</html>


### PR DESCRIPTION
Copy the jinja template string in render.py to a file, templates/tracing/trace.html. The templates directory should be next to the src directory.