### PR TITLE
Add Issue Dependencies Function

### DIFF
--- a/src/repo.py
+++ b/src/repo.py
@@ -1,3 +1,4 @@
+import re
 from git import Repo
 from github import Github
 import os
@@ -159,3 +160,15 @@ def check_issue_has_open_pr_with_same_title(repo_name: str, issue_title: str) ->
     repo = g.get_repo(repo_name)
     pull_requests = repo.get_pulls(state="open")
     return any(issue_title == pr.title for pr in pull_requests)
+
+
+def get_issue_dependencies(repo_name: str, issue_number: int) -> list[int]:
+    api_key = os.environ["GITHUB_API_KEY"]
+    g = Github(api_key)
+    repo = g.get_repo(repo_name)
+    issue = repo.get_issue(issue_number)
+    issue_body = issue.body
+    pattern = r"#\d+"
+    matches = re.findall(pattern, issue_body)
+    dependencies = [int(match.replace("#", "")) for match in matches]
+    return dependencies


### PR DESCRIPTION
Add a function to repo.py that takes a repo name and issue number, and returns an integer list of the issues that this issue depends on.

Issue dependencies are marked by a reference to the other issue in the body, like this: #650 