### PR TITLE
Add embeddings function

### DIFF
--- a/src/gpt.py
+++ b/src/gpt.py
@@ -7,6 +7,7 @@ from tracing.trace import trace
 from tracing.tags import GPT_INPUT, GPT_OUTPUT
 from cache import memoize
 from utilities.prompts import load_prompt
+import numpy as np
 
 GPT_3_5 = "gpt-3.5-turbo-0613"
 GPT_4 = "gpt-4-0613"
@@ -82,3 +83,12 @@ def gpt_query(
 
 if not disable_cache:
     gpt_query = memoize(gpt_query)
+
+
+def calculate_text_embedding(text: str) -> np.ndarray:
+    openai.api_key = os.getenv("OPENAI_API_KEY")
+    embedding_result = openai.Embedding.create(
+        model="text-embedding-ada-002", input=text
+    )
+
+    return np.array(embedding_result["data"][0]["embedding"])


### PR DESCRIPTION
Add a function to gpt.py which uses OpenAI's Python API to calculate an embedding vector for a piece of text, and returns a numpy vec.

Here is an example of what the API call is using openai's python library.

import os
import openai
openai.api_key = os.getenv("OPENAI_API_KEY")
openai.Embedding.create(
  model="text-embedding-ada-002",
  input="The food was delicious and the waiter..."
)

The result will be something like:

{
  "object": "list",
  "data": [
    {
      "object": "embedding",
      "embedding": [
        0.0023064255,
        -0.009327292,
        .... (1536 floats total for ada-002)
        -0.0028842222,
      ],
      "index": 0
    }
  ],
  "model": "text-embedding-ada-002",
  "usage": {
    "prompt_tokens": 8,
    "total_tokens": 8
  }
}