### PR TITLE
Modify GPT Caching

### DIFF
--- a/src/gpt.py
+++ b/src/gpt.py
@@ -13,7 +13,6 @@ GPT_3_5 = "gpt-3.5-turbo-0613"
 GPT_4 = "gpt-4-0613"
 SYSTEM_CHECK_FUNC = load_prompt("check")
 SYSTEM_COMMAND_FUNC = load_prompt("command")
-disable_cache = True
 
 
 def gpt_query(
@@ -79,10 +78,6 @@ def gpt_query(
         trace(GPT_OUTPUT, content, (tokens_in, tokens_out))
         cprint(f"GPT Output: {content}", "cyan")
         return content
-
-
-if not disable_cache:
-    gpt_query = memoize(gpt_query)
 
 
 def calculate_text_embedding(text: str) -> np.ndarray:

--- a/src/pipeline/issue.py
+++ b/src/pipeline/issue.py
@@ -1,8 +1,3 @@
-from tools.imports import imports
-from tools.search import search_tool  # Importing search_tool
-from tools.pylint import run_pylint  # Importing run_pylint
-from tools.pytest import run_pytest  # Importing run_pytest
-from black import FileMode, format_str
 import os
 import uuid
 import subprocess
@@ -23,6 +18,11 @@ from commands.loop import command_loop_new  # Importing command_loop_new
 import repo
 import shutil
 from repo import Issue
+from tools.imports import imports
+from tools.search import search_tool  # Importing search_tool
+from tools.pylint import run_pylint  # Importing run_pylint
+from tools.pytest import run_pytest  # Importing run_pytest
+from black import FileMode, format_str
 
 CHECK_OPEN_PR = False
 
@@ -87,7 +87,7 @@ def apply_prompt_to_files(prompt: str, files: dict) -> dict:
     scratch = "Available files: " + ", ".join(files.keys()) + "\n"
 
     command, state = command_loop_new(
-        scratch + f"{str(uuid.uuid4())}\n{prompt}",
+        scratch + f"{prompt}",
         gpt.SYSTEM_COMMAND_FUNC,
         COMMANDS_GENERATE,
         files,


### PR DESCRIPTION
In gpt.py, remove the disable_cache constant, and never cache gpt_query. 

Remove the uuid prepended to the prompt in apply_prompt_to_files.