### PR TITLE
Apply prompt in evals

### DIFF
--- a/src/evals/evals.py
+++ b/src/evals/evals.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from typing import List
 import yaml
 from tools.pytest import run_pytest
+from repo import git_reset
+from pipeline.issue import apply_prompt_to_directory
 
 
 @dataclass
@@ -11,6 +13,8 @@ class Eval:
 
 
 def run_eval(eval: Eval, directory: str):
+    git_reset(directory)
+    apply_prompt_to_directory(eval.prompt, directory)
     test_names = " ".join(eval.tests)
     result = run_pytest(f"{directory}/src", test_names)
     if result is not None:

--- a/src/repo.py
+++ b/src/repo.py
@@ -4,6 +4,7 @@ from github import Github
 import os
 from dataclasses import dataclass
 import time
+import subprocess
 
 
 def switch_and_reset_branch(branch_id: str, target_dir: str = os.getcwd()):
@@ -181,3 +182,10 @@ def check_dependency_issues(repo_name: str, issue_number: int) -> bool:
         if is_issue_open(repo_name, dep):
             return True
     return False
+
+
+def git_reset(directory: str):
+    try:
+        subprocess.check_call(["git", "reset", "--hard"], cwd=directory)
+    except subprocess.CalledProcessError as e:
+        raise Exception("git reset failed") from e


### PR DESCRIPTION
In run_eval,

1) Call git reset on the current directory from repo.py
2) Call apply_prompt_to_directory to apply the prompt of the eval to the eval's directory
3) Then run the existing testing logic in the function

Depends on #684 