### PR TITLE
Add context dict to load_prompt

### DIFF
--- a/src/utilities/prompts.py
+++ b/src/utilities/prompts.py
@@ -1,8 +1,12 @@
 import jinja2
 
 
-def load_prompt(prompt_name):
+def load_prompt(prompt_name, context=None):
     template_loader = jinja2.FileSystemLoader(searchpath="./prompts/")
     template_env = jinja2.Environment(loader=template_loader)
     template = template_env.get_template(prompt_name + ".txt")
-    return template.render()
+
+    if context:
+        return template.render(context)
+    else:
+        return template.render()


### PR DESCRIPTION
Add an optional parameter to load_prompt, which is a dict called context. It should contain key value pairs that are passed through to jinja to be available when the templates are rendered.