### PR TITLE
Add advice tool

### DIFF
--- a/src/tools/advice.py
+++ b/src/tools/advice.py
@@ -1,0 +1,13 @@
+import os
+from utilities.prompts import load_prompt
+from gpt import gpt_query
+
+
+def generate_advice(goal: str) -> str:
+    prompt = load_prompt("advice.txt")
+    goal_dict = {"goal": goal}
+    response = gpt_query(
+        message=goal_dict,
+        system="Given the stated goal, return a list of the advice that is relevant",
+    )
+    return response


### PR DESCRIPTION
Add a tools/advice.py, which contains a generate_advice function.

It should:

1) Take a goal string as a parameter
2) Load the advice.txt prompt using load_prompt, passing in a context dict with "goal" as a key, and the goal string as a value
3) Query GPT 3.5 with this prompt with the system message "Given the stated goal, return a list of the advice that is relevant" 

Depends on #694