### PR TITLE
Make function calls optional in Command Loop

### DIFF
--- a/src/commands/loop.py
+++ b/src/commands/loop.py
@@ -33,6 +33,10 @@ def command_loop_new(prompt: str, system: str, command_classes: list, files: dic
             result = gpt_query(
                 prompt + "\n" + state.scratch, system, extract_schemas(command_classes)
             )
+
+            if isinstance(result, str):
+                return (result, state)
+
             command = parse_gpt_response(command_classes, result)
 
             if command.terminal:


### PR DESCRIPTION
In command_loop_new, pass require_functions=False to gpt_query. If a string is returned from gpt_query in this loop, treat it as a terminal response, breaking out of the loop.