### PR TITLE
Add an AST tool

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,7 @@ pylint==2.17.4
 PyNaCl==1.5.0
 pytest==7.3.1
 PyYAML==6.0
+repo==0.3.0
 requests==2.30.0
 smmap==5.0.0
 termcolor==2.3.0

--- a/src/tools/ast.py
+++ b/src/tools/ast.py
@@ -1,0 +1,27 @@
+import ast
+import astor
+
+
+def replace_node(src_code, target_node, new_code):
+    # Parse the source code into an AST
+    tree = ast.parse(src_code)
+
+    # Iterate over all nodes in the AST
+    for node in ast.walk(tree):
+        # Replace the node if its name matches the target
+        if (
+            isinstance(node, (ast.FunctionDef, ast.ClassDef))
+            and node.name == target_node
+        ):
+            new_tree = ast.parse(new_code)
+            if isinstance(new_tree, ast.Module):
+                new_node = new_tree.body[0]
+                node.name = new_node.name
+                node.args = new_node.args
+                node.body = new_node.body
+                node.decorator_list = new_node.decorator_list
+                node.returns = new_node.returns
+                break
+
+    # Generate updated source code from the modified AST
+    return astor.to_source(tree)


### PR DESCRIPTION
Create a new tools/ast.py, which will contain Python AST tools.

Create a function called replace_node, which takes

1) A string containing a file of Python source code
2) A string containing the name of a node (function or class) to replace
3) A string containing a string of Python source code to replace it with.

The function should parse the Python source code, parse the replacement Python source code, iterate over the AST, and replace the old version of the function or class with the new version. 

It should then return new source code for the Python file.

Use the astor library for these operations.