### PR TITLE
Add Parent Git Directory function

### DIFF
--- a/src/repo.py
+++ b/src/repo.py
@@ -189,3 +189,14 @@ def git_reset(directory: str):
         subprocess.check_call(["git", "reset", "--hard"], cwd=directory)
     except subprocess.CalledProcessError as e:
         raise Exception("git reset failed") from e
+
+
+def find_git_repo(directory: str) -> str:
+    while directory != os.path.dirname(directory):  # While the directory has a parent
+        try:
+            Repo(directory)  # Try to create a Repo object
+            return directory  # If successful, return the directory
+        except Exception:
+            pass
+        directory = os.path.dirname(directory)  # Go up one directory level
+    return None


### PR DESCRIPTION
Add a function to repo.py that takes a directory, and then walks up its parent directories until it finds a git repo (it may be the same directory). Return this new directory as a string.