### PR TITLE
Fix advice path

### DIFF
--- a/src/tools/advice.py
+++ b/src/tools/advice.py
@@ -4,7 +4,7 @@ from gpt import gpt_query
 
 
 def generate_advice(goal: str) -> str:
-    prompt = load_prompt("advice.txt", {"goal": goal})
+    prompt = load_prompt("advice", {"goal": goal})
     response = gpt_query(
         message=prompt,
         system="Given the stated goal, return a list of the advice that is relevant",


### PR DESCRIPTION
In generate_advice, load_prompt paths shouldn't contain a trailing .txt