### PR TITLE
Clean up PyLint return

### DIFF
--- a/src/tools/pylint.py
+++ b/src/tools/pylint.py
@@ -14,6 +14,6 @@ def run_pylint(directory: str, warnings: bool = False) -> str:
         text=True,
     )
     if proc.returncode != 0:
-        return proc.stdout
+        return proc.stdout.replace(directory, "")
     else:
         return None


### PR DESCRIPTION
In run_pylint, where an error is returned, postprocess the string by doing a find/replace of the directory to empty string. Return this postprocessed string.