### PR TITLE
Don't use numpy arrays for embeddings

### DIFF
--- a/src/gpt.py
+++ b/src/gpt.py
@@ -7,7 +7,6 @@ from tracing.trace import trace
 from tracing.tags import GPT_INPUT, GPT_OUTPUT
 from cache import memoize
 from utilities.prompts import load_prompt
-import numpy as np
 
 GPT_3_5 = "gpt-3.5-turbo-0613"
 GPT_4 = "gpt-4-0613"
@@ -81,13 +80,13 @@ def gpt_query(
 
 
 @memoize
-def calculate_text_embedding(text: str) -> np.ndarray:
+def calculate_text_embedding(text: str):
     openai.api_key = os.getenv("OPENAI_API_KEY")
     embedding_result = openai.Embedding.create(
         model="text-embedding-ada-002", input=text
     )
 
-    return np.array(embedding_result["data"][0]["embedding"])
+    return list(embedding_result["data"][0]["embedding"])
 
 
 @memoize


### PR DESCRIPTION
Remove the numpy array logic from calculate_text_embedding, instead returning a normal Python array.