### PR TITLE
Add src to pylint issues

### DIFF
--- a/src/tools/pylint.py
+++ b/src/tools/pylint.py
@@ -14,6 +14,6 @@ def run_pylint(directory: str, warnings: bool = False) -> str:
         text=True,
     )
     if proc.returncode != 0:
-        return proc.stdout.replace(directory, "")
+        return proc.stdout.replace(directory, "src")
     else:
         return None


### PR DESCRIPTION
In pylint.py, when the target directory is being replaced with an empty string, instead replace it with "src"