### PR TITLE
Add function to turn paths to namespaces

### DIFF
--- a/src/tools/move_file.py
+++ b/src/tools/move_file.py
@@ -13,3 +13,9 @@ def move_file(file_mapping, old_path, new_path):
         raise Exception(f"No such file: '{old_path}'")
 
     return file_mapping_copy
+
+
+def path_to_namespace(file_path):
+    if file_path.startswith("src/") and file_path.endswith(".py"):
+        file_path = file_path[4:-3]
+    return file_path.replace("/", ".")


### PR DESCRIPTION
Add a function to move_file.py that takes a path file, and returns a namespace, leaving off the "src"

For instance, "tools/repo.py" becomes "tools.repo"