### PR TITLE
Add function to fix up imports

### DIFF
--- a/src/tools/move_file.py
+++ b/src/tools/move_file.py
@@ -19,3 +19,11 @@ def path_to_namespace(file_path):
     if file_path.startswith("src/") and file_path.endswith(".py"):
         file_path = file_path[4:-3]
     return file_path.replace("/", ".")
+
+
+def fix_imports(file_string, old_namespace, new_namespace):
+    lines = file_string.split("\n")
+    for i, line in enumerate(lines):
+        if "import" in line:
+            lines[i] = line.replace(old_namespace, new_namespace)
+    return "\n".join(lines)


### PR DESCRIPTION
Add a function to move_file.py called fix_imports, which takes a file string, an old namespace name, and a new namespace name.

For each line of the file input, if "import" is in the line, replace the old namespace name with the new namespace name (if it exists).

Return the updated file as a string.