### PR TITLE
Fix imports in Move File

### DIFF
--- a/src/tools/move_file.py
+++ b/src/tools/move_file.py
@@ -7,8 +7,17 @@ def move_file(file_mapping, old_path, new_path):
 
     if old_path in file_mapping_copy:
         # Moving the file to the new path
-        file_mapping_copy[new_path] = file_mapping_copy[old_path]
-        del file_mapping_copy[old_path]
+        file_mapping_copy[new_path] = file_mapping_copy.pop(old_path)
+
+        # Generate old_namespace and new_namespace
+        old_namespace = path_to_namespace(old_path)
+        new_namespace = path_to_namespace(new_path)
+
+        # Iterating over each file and fix broken import paths if any
+        for file_path, file_content in file_mapping_copy.items():
+            file_mapping_copy[file_path] = fix_imports(
+                file_content, old_namespace, new_namespace
+            )
     else:
         raise Exception(f"No such file: '{old_path}'")
 


### PR DESCRIPTION
In move_file.py, update the move_file function. Iterate over the values of file_mapping_copy, which is a list of files in the project.

For each file, update it with fix_imports, using the old and new namespaces generated from path_to_namespace with old_path and new_path.