### PR TITLE
Use parent directory in apply_prompt_to_directory

### DIFF
--- a/src/pipeline/issue.py
+++ b/src/pipeline/issue.py
@@ -72,9 +72,10 @@ def apply_prompt_to_files(prompt: str, files: dict) -> dict:
 
 
 def apply_prompt_to_directory(prompt: str, target_dir: str) -> None:
+    git_parent_dir = os.path.dirname(target_dir)
     files = {
         f: read_file(os.path.join(target_dir, f))
-        for f in repo.get_all_checked_in_files(target_dir)
+        for f in repo.get_all_checked_in_files(git_parent_dir)
         if os.path.isfile(os.path.join(target_dir, f))
     }
     updated_files = apply_prompt_to_files(prompt, files)

--- a/src/repo.py
+++ b/src/repo.py
@@ -127,12 +127,26 @@ def commit_local_modifications(
 
 
 def get_all_checked_in_files(target_dir: str = os.getcwd()):
-    repo = Repo(target_dir)
+    # find the git parent directory
+    parent_dir = find_git_repo(target_dir)
+
+    # make repo object of the parent directory
+    repo = Repo(parent_dir)
+
+    # list of all files in the parent directory
     file_list = []
     for obj in repo.tree().traverse():
         if obj.type == "blob":
             file_list.append(obj.path)
-    return file_list
+
+    # filter file list to only include files in the target directory
+    target_files = []
+    target_path = os.path.relpath(target_dir, parent_dir)
+    for file in file_list:
+        if file.startswith(target_path):
+            target_files.append(file)
+
+    return target_files
 
 
 def fetch_new_changes(target_dir: str = os.getcwd()):


### PR DESCRIPTION
Refactor apply_prompt_to_directory to be able to be called on a git subdirectory.

It should use the find_git_repo function to search for the location of the git repository in a parent directory. Then for each file get_all_checked_in_files returns, ensure that it exists in target_dir