### PR TITLE
Update imports relative instruction

### DIFF
--- a/src/pipeline/issue.py
+++ b/src/pipeline/issue.py
@@ -62,7 +62,11 @@ def apply_prompt_to_files(prompt: str, files: dict) -> dict:
         "files": ", ".join(files.keys()),
         "advice": advice,
         "goal": prompt,
-        "details": "Imports should be relative to " + settings.CODE_PATH,
+        "details": "Imports should be relative to "
+        + settings.CODE_PATH
+        + ", so "
+        + settings.CODE_PATH
+        + "/cat/dog.py should be imported as 'cat.dog'",
     }
     prompt = load_prompt("issue", context)
 


### PR DESCRIPTION
Update the import advice in apply_prompt_to_files, right now it reads:

"Imports should be relative to src"

It should read

"Imports should be relative to src, so src/cat/dog.py should be imported as 'import cat.dog'"

But use the CODE_PATH constant to construct the sentence.