### PR TITLE
Remove function calls from scratch

### DIFF
--- a/src/commands/loop.py
+++ b/src/commands/loop.py
@@ -45,8 +45,6 @@ def command_loop_new(prompt: str, system: str, command_classes: list, files: dic
 
             output = command.execute(state)
 
-            state.scratch += "\n" + str(command)
-
             state.scratch += "\n" + output
 
             exception_count = 0


### PR DESCRIPTION
In loop.py, remove the line that adds the stringified command to the state's scratch property.