### PR TITLE
Fix advice prompt

### DIFF
--- a/prompts/advice.txt
+++ b/prompts/advice.txt
@@ -1,6 +1,6 @@
 ### GOAL ###
 
-{goal}
+{{ goal }}
 
 ### ADVICE ###
 


### PR DESCRIPTION
In advice.txt, the {goal} variable doesn't use correct jinja2 syntax.