### PR TITLE
Fix Repository Path hardcoding

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -52,7 +52,7 @@ def main(dry_run=False, issue_name=None) -> None:
                 trace_instance = create_trace(f"{issue.title}")
                 bind_trace(trace_instance)
                 try:
-                    process_issue(issue, dry_run)
+                    process_issue(issue, dry_run, settings.REPOSITORY_PATH)
                     break
                 except Exception as e:
                     cprint(


### PR DESCRIPTION
In process_issue, don't use the settings.REPOSITORY_PATH constant directly, instead take it as a parameter to the function. Update callers of the function to pass in settings.REPOSITORY_PATH