### PR TITLE
Add retrieve to VectorIndex

### DIFF
--- a/src/tools/index.py
+++ b/src/tools/index.py
@@ -11,3 +11,9 @@ class VectorIndex:
         embedding = calculate_text_embedding(source_code)
         embedding = np.array(embedding)
         self.store.add_entry(embedding, source_code)
+
+    def retrieve(self, search_text, num_items):
+        embedding = calculate_text_embedding(search_text)
+        embedding = np.array(embedding)
+        entries = self.store.search(embedding, num_items)
+        return entries


### PR DESCRIPTION
Add a retrieve function to VectorIndex. It should take search text, as well as a number of items to search for. 

Calculate the embedding of the search text, and call search on the store to get a list of entries. Return this list.