### PR TITLE
Add check to see if repository exists

### DIFF
--- a/src/pipeline/issue.py
+++ b/src/pipeline/issue.py
@@ -111,6 +111,9 @@ def process_issue(issue: Issue, dry_run: bool) -> None:
         issue.repository, issue.title
     ):
         return
+    if not repo.repository_exists(issue.repository):
+        print(f"Error: The repository {issue.repository} does not exist.")
+        return
     target_dir = f"target/issue-{issue.number}/{issue.repository}"
     if os.path.exists(target_dir):
         shutil.rmtree(target_dir, ignore_errors=True)

--- a/src/repo.py
+++ b/src/repo.py
@@ -218,3 +218,17 @@ def list_files(target_directory, gitignore_path):
             if not spec.match_file(relative_path):
                 matches.append(relative_path)
     return matches
+
+
+def repository_exists(repo_name: str) -> bool:
+    api_key = os.environ["GITHUB_API_KEY"]
+    g = Github(api_key)
+    try:
+        repo = g.get_repo(repo_name)
+        return True
+    except Exception as e:
+        print(f'Error: The repository "{repo_name}" does not exist.')
+        return False
+
+
+### NEW FILE src/pipeline/issue.py ###


### PR DESCRIPTION
In repo.py, add a check to see if a given repository exists. Then use this at the start of process_repository to bail out if the given repository doesn't exist, printing an error but not raising an exception.