### PR TITLE
Make IssueState json serializable

### DIFF
--- a/src/pipeline/issue_state.py
+++ b/src/pipeline/issue_state.py
@@ -16,3 +16,9 @@ class IssueState:
 
     def store(self):
         write(f"issue-{self.id}.json", self)
+
+    def __dict__(self):
+        return self.__dict__.copy()
+
+    def __str__(self):
+        return str(self.__dict__)


### PR DESCRIPTION
IssueState can't be written to the KeyValueStore because json.dump can't be called on it. Make it json serializable.