### PR TITLE
Specify imports should be at the top of the file

### DIFF
--- a/prompts/replace.txt
+++ b/prompts/replace.txt
@@ -12,3 +12,4 @@ Requirements:
 9) Do not include the file name or any other content that should not be included in the file itself.
 10) Do not include the contents of any other file.
 11) Use project relative imports. e.g. to import 'src/a/b.py', write 'import a.b'.
+12) All imports should live at the top of the file, before any other code.


### PR DESCRIPTION
In the replace.txt prompt, add the following piece of advice:

"All imports should live at the top of the file, before any other code."