### PR TITLE
Add shell command to run duopoly in a loop

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Check if traces/ directory exists. If it does, delete it.
+if [ -d "traces/" ]; then
+	rm -rf traces/
+fi
+
+# Create a new traces/ directory
+mkdir traces/
+
+# Run a python web server on port 8000 in the background
+nohup python3 -m http.server -d traces/ 8000 > /dev/null 2>&1 &
+
+while true
+do
+	# Update git repo
+	git pull
+
+	# Install requirements
+	pip3 install -q -r requirements.txt
+
+	# Run the python script
+	python3 src/main.py
+
+	# Sleep for 100 hours
+	sleep 360000
+	
+	# Exit the loop
+	break
+done


### PR DESCRIPTION
Add a run.sh command, which:

* deletes traces/ directory if it exists
* recreates it
* runs a Python inbuilt web server from the traces/ subdirectory in the background on port 8000

Then enters a loop:

* Update the git repo
* Install requirements with pip3 install -q -r requirements.txt
* Run duopoly with python3 src/main.py
* Sleep for 100 hours
* Exit