### PR TITLE
Add wrapping to traces

### DIFF
--- a/templates/tracing/trace.html
+++ b/templates/tracing/trace.html
@@ -13,6 +13,9 @@
 				color: {{ colors['text'] }};
 			}
 			{% endfor %}
+			pre {
+			    word-wrap: break-word;
+			}
 		</style>
 	</head>
 	<body>


### PR DESCRIPTION
In render.py, add wrapping to the html text elements.