### PR TITLE
Tweak retries

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -13,7 +13,7 @@ import ast
 import astor
 import settings
 
-MAX_RETRIES = 1
+MAX_RETRIES = 3
 
 
 def merge_approved_prs(repository) -> None:

--- a/src/pipeline/issue.py
+++ b/src/pipeline/issue.py
@@ -90,7 +90,7 @@ def apply_prompt_to_directory(prompt: str, target_dir: str) -> None:
 
 def process_directory(prompt: str, target_dir: str) -> None:
     apply_prompt_to_directory(prompt, target_dir)
-    for iteration in range(3):
+    for iteration in range(1):
         pylint_result = run_pylint(os.path.join(target_dir, "src"))
         if pylint_result is not None and iteration < 2:
             apply_prompt_to_directory(


### PR DESCRIPTION
In issue.py, only iterate once in process_directory on pylint errors. However, make MAX_RETRIES in main.py 3.

Don't use replace_node because of a bug in Duopoly :)