### PR TITLE
Fix run script color printing

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -15,15 +15,15 @@ while true
 do
 	# Update git repo
 	git pull
-
+	
 	# Install requirements
 	pip3 install -q -r requirements.txt
-
+	
 	# Run the python script
 	python3 src/main.py
-
-	echo -e "\e[95mexecution successful\e[0m"
-
+	
+	echo -e '\033[95mexecution successful\033[0m'
+	
 	# Sleep for 100 hours
 	sleep 360000
 	


### PR DESCRIPTION
The run.sh script is meant to print "execution successful" in color, but instead in my terminal it looks like this: \e[95mexecution successful\e[0m. Please fix!