### PR TITLE
Make replace node handle constants

### DIFF
--- a/src/tools/code.py
+++ b/src/tools/code.py
@@ -9,19 +9,28 @@ def replace_node(src_code, target_node, new_code):
     # Iterate over all nodes in the AST
     for node in ast.walk(tree):
         # Replace the node if its name matches the target
-        if (
-            isinstance(node, (ast.FunctionDef, ast.ClassDef))
-            and node.name == target_node
+        if isinstance(node, (ast.FunctionDef, ast.ClassDef, ast.Assign)) and (
+            (hasattr(node, "name") and node.name == target_node)
+            or (
+                isinstance(node, ast.Assign)
+                and isinstance(node.targets[0], ast.Name)
+                and node.targets[0].id == target_node
+            )
         ):
             new_tree = ast.parse(new_code)
-            if isinstance(new_tree, ast.Module):
-                new_node = new_tree.body[0]
+            new_node = new_tree.body[0]
+
+            if isinstance(node, (ast.FunctionDef, ast.ClassDef)):
                 node.name = new_node.name
-                node.args = new_node.args
-                node.body = new_node.body
-                node.decorator_list = new_node.decorator_list
-                node.returns = new_node.returns
-                break
+                if isinstance(new_node, (ast.FunctionDef, ast.ClassDef)):
+                    node.args = new_node.args
+                    node.body = new_node.body
+                    node.decorator_list = new_node.decorator_list
+                    node.returns = new_node.returns
+            elif isinstance(node, ast.Assign):
+                if isinstance(new_node, ast.Assign):
+                    node.targets[0].id = new_node.targets[0].id
+                    node.value = new_node.value
 
     # Generate updated source code from the modified AST
     return astor.to_source(tree)

--- a/src/tools/test_code.py
+++ b/src/tools/test_code.py
@@ -25,7 +25,6 @@ def test_replace_node():
     assert "Hello, world!" not in result
 
 
-@pytest.mark.skip
 def test_replace_constant():
     # Use the replace_node function to replace the CONSTANT
     # with the NEW_CONSTANT


### PR DESCRIPTION
Constants aren't currently handled in replace_node in code.py. Fix that, and then update test_code.py to not ignore the constant test.