### PR TITLE
Add function to check if a PR has a conflict

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -20,6 +20,10 @@ def merge_approved_prs(repository) -> None:
     is_merged = False
     approved_prs = repo.find_approved_prs(repository)
     for pr_id in approved_prs:
+        # Check if PR has a merge conflict
+        if repo.check_pr_conflict(repository, pr_id):
+            cprint(f"PR {pr_id} has conflict. Skipping merge.", "red")
+            continue
         for attempt in range(5):
             if repo.merge_with_rebase_if_possible(repository, pr_id):
                 print(f"Merged PR: {pr_id}")

--- a/src/repo.py
+++ b/src/repo.py
@@ -200,6 +200,15 @@ def check_dependency_issues(issue: Issue) -> bool:
     return False
 
 
+def check_pr_conflict(repo_name: str, pr_id: int) -> bool:
+    """Checks if a PR has a conflict."""
+    api_key = os.environ["GITHUB_API_KEY"]
+    g = Github(api_key)
+    repo = g.get_repo(repo_name)
+    pr = repo.get_pull(pr_id)
+    return not pr.mergeable
+
+
 def git_reset(directory: str):
     try:
         subprocess.check_call(["git", "reset", "--hard"], cwd=directory)


### PR DESCRIPTION
In repo.py, add a function that checks if a PR with the given ID has a merge conflict.

In main.py, merge_approved_prs, skip merging a PR if there's a conflict. Print a red message instead that says there's a conflict.