### PR TITLE
Fix replace_node to support dataclasses

### DIFF
--- a/src/tools/code.py
+++ b/src/tools/code.py
@@ -3,34 +3,31 @@ import astor
 
 
 def replace_node(src_code, target_node, new_code):
-    # Parse the source code into an AST
     tree = ast.parse(src_code)
-
-    # Iterate over all nodes in the AST
     for node in ast.walk(tree):
-        # Replace the node if its name matches the target
         if isinstance(node, (ast.FunctionDef, ast.ClassDef, ast.Assign)) and (
-            (hasattr(node, "name") and node.name == target_node)
-            or (
-                isinstance(node, ast.Assign)
-                and isinstance(node.targets[0], ast.Name)
-                and node.targets[0].id == target_node
-            )
+            hasattr(node, "name")
+            and node.name == target_node
+            or isinstance(node, ast.Assign)
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == target_node
         ):
             new_tree = ast.parse(new_code)
             new_node = new_tree.body[0]
-
             if isinstance(node, (ast.FunctionDef, ast.ClassDef)):
                 node.name = new_node.name
-                if isinstance(new_node, (ast.FunctionDef, ast.ClassDef)):
+                if isinstance(new_node, ast.FunctionDef):
                     node.args = new_node.args
                     node.body = new_node.body
                     node.decorator_list = new_node.decorator_list
                     node.returns = new_node.returns
+                elif isinstance(new_node, ast.ClassDef):
+                    node.bases = new_node.bases
+                    node.keywords = new_node.keywords
+                    node.body = new_node.body
+                    node.decorator_list = new_node.decorator_list
             elif isinstance(node, ast.Assign):
                 if isinstance(new_node, ast.Assign):
                     node.targets[0].id = new_node.targets[0].id
                     node.value = new_node.value
-
-    # Generate updated source code from the modified AST
     return astor.to_source(tree)

--- a/src/tools/test_code.py
+++ b/src/tools/test_code.py
@@ -39,7 +39,6 @@ def test_replace_node():
     assert "Hello, world!" not in result
 
 
-@pytest.mark.skip(reason="Dataclass replacement test doesn't functioning properly yet.")
 def test_replace_dataclass():
     # Use the replace_node function to replace the Dataclass
     # with the NEW_DATA_CLASS


### PR DESCRIPTION
In code.py, replace_node fails like this when replacing a class. There's a test that's ignored in test_code.py. Fix replace_node to support classes, then stop ignoring the test.

Failure exception: "AttributeError: 'ClassDef' object has no attribute 'args'"