### PR TITLE
Allow not requesting reviewers

### DIFF
--- a/src/repo.py
+++ b/src/repo.py
@@ -43,11 +43,14 @@ def push_local_branch_to_origin(branch_id: str, target_dir: str = os.getcwd()):
 
 
 def create_pull_request(repo_name: str, branch_id: str, title: str, body: str):
+    from src.settings import REQUEST_REVIEW_FOR_PRS
+
     api_key = os.environ["GITHUB_API_KEY"]
     g = Github(api_key)
     repo = g.get_repo(repo_name)
     pr = repo.create_pull(title=title, body=body, head=branch_id, base="main")
-    pr.create_review_request(reviewers=["reitzensteinm"])
+    if REQUEST_REVIEW_FOR_PRS:
+        pr.create_review_request(reviewers=["reitzensteinm"])
 
 
 def find_approved_prs(repo_name: str) -> list[int]:
@@ -185,7 +188,7 @@ def get_issue_dependencies(repo_name: str, issue_number: int) -> list[int]:
     repo = g.get_repo(repo_name)
     issue = repo.get_issue(issue_number)
     issue_body = issue.body
-    pattern = "#\d+"
+    pattern = "#\\d+"
     matches = re.findall(pattern, issue_body)
     dependencies = [int(match.replace("#", "")) for match in matches]
     return dependencies

--- a/src/settings.py
+++ b/src/settings.py
@@ -3,3 +3,4 @@ CODE_PATH = "src"
 GITIGNORE_PATH = ".gitignore"
 ADMIN_USERS = ["reitzensteinm"]
 TOKEN_LIMIT = 40000
+REQUEST_REVIEW_FOR_PRS = True


### PR DESCRIPTION
Prompt: "
Add a new setting to settings.py called REQUEST_REVIEW_FOR_PRS, defaulting to True. Alter create_pull_request so that it imports that setting and, if it's False, it doesn't request a reviewer.


"