### PR TITLE
Make quality checks configurable

### DIFF
--- a/src/pipeline/issue.py
+++ b/src/pipeline/issue.py
@@ -90,19 +90,21 @@ def apply_prompt_to_directory(prompt: str, target_dir: str) -> None:
 
 def process_directory(prompt: str, target_dir: str) -> None:
     apply_prompt_to_directory(prompt, target_dir)
-    for iteration in range(1):
-        pylint_result = run_pylint(os.path.join(target_dir, "src"))
-        if pylint_result is not None and iteration < 2:
-            apply_prompt_to_directory(
-                f"Fix these errors identified by PyLint:\n{pylint_result}", target_dir
-            )
-        elif pylint_result is not None and iteration == 2:
-            raise Exception("Pylint failed\n" + pylint_result)
-        elif pylint_result is None:
-            break
-    pytest_result = run_pytest(os.path.join(target_dir, "src"))
-    if pytest_result is not None:
-        raise Exception("Pytest failed\n" + pytest_result)
+    if settings.DO_QUALITY_CHECKS:
+        for iteration in range(1):
+            pylint_result = run_pylint(os.path.join(target_dir, "src"))
+            if pylint_result is not None and iteration < 2:
+                apply_prompt_to_directory(
+                    f"Fix these errors identified by PyLint:\n{pylint_result}",
+                    target_dir,
+                )
+            elif pylint_result is not None and iteration == 2:
+                raise Exception("Pylint failed\n" + pylint_result)
+            elif pylint_result is None:
+                break
+        pytest_result = run_pytest(os.path.join(target_dir, "src"))
+        if pytest_result is not None:
+            raise Exception("Pytest failed\n" + pytest_result)
 
 
 def get_target_dir(issue):

--- a/src/settings.py
+++ b/src/settings.py
@@ -3,3 +3,4 @@ CODE_PATH = "src"
 GITIGNORE_PATH = ".gitignore"
 ADMIN_USERS = ["reitzensteinm"]
 TOKEN_LIMIT = 40000
+DO_QUALITY_CHECKS = True


### PR DESCRIPTION
Prompt: "Add a new setting to settings.py called DO_QUALITY_CHECKS, defaulting to True.

Alter process_directory in issue.py so that if DO_QUALITY_CHECKS is False, it only does `apply_prompt_to_directory` and none of the following bits of code which run pylint and pytest."