### PR TITLE
Configurable reviewer username

### DIFF
--- a/src/repo.py
+++ b/src/repo.py
@@ -43,14 +43,14 @@ def push_local_branch_to_origin(branch_id: str, target_dir: str = os.getcwd()):
 
 
 def create_pull_request(repo_name: str, branch_id: str, title: str, body: str):
-    from settings import REQUEST_REVIEW_FOR_PRS
+    from settings import REQUEST_REVIEW_FOR_PRS, PR_REVIEWER_USERNAME
 
     api_key = os.environ["GITHUB_API_KEY"]
     g = Github(api_key)
     repo = g.get_repo(repo_name)
     pr = repo.create_pull(title=title, body=body, head=branch_id, base="main")
     if REQUEST_REVIEW_FOR_PRS:
-        pr.create_review_request(reviewers=["reitzensteinm"])
+        pr.create_review_request(reviewers=[PR_REVIEWER_USERNAME])
 
 
 def find_approved_prs(repo_name: str) -> list[int]:

--- a/src/settings.py
+++ b/src/settings.py
@@ -5,3 +5,4 @@ ADMIN_USERS = ["reitzensteinm"]
 TOKEN_LIMIT = 40000
 DO_QUALITY_CHECKS = True
 REQUEST_REVIEW_FOR_PRS = True
+PR_REVIEWER_USERNAME = "reitzensteinm"


### PR DESCRIPTION
Prompt: "Add a new setting to settings.py called PR_REVIEWER_USERNAME. Alter `create_pull_request` so that it uses that new setting to set the sole reviewer."

Via @atroche ([942](https://github.com/reitzensteinm/duopoly/pull/942)) - PRs with merge conflicts aren't yet supported