### PR TITLE
Support quoted code in modify_file

### DIFF
--- a/src/tools/replace_file.py
+++ b/src/tools/replace_file.py
@@ -1,5 +1,6 @@
 from gpt import gpt_query
 from utilities.prompts import load_prompt
+import re
 
 SYSTEM_REPLACE_THINK = load_prompt("replace_think")
 
@@ -16,5 +17,11 @@ def modify_file(original_file, instructions, context="", file_name=None):
     thinking = gpt_query(instructions, SYSTEM_REPLACE_THINK)
     instructions = f"{instructions}\n{thinking}\n{new_file_text}"
     new_file = gpt_query(instructions, SYSTEM_REPLACE)
+
+    # Remove Markdown code quotes.
+    new_file = re.sub(r"```[\w]*\n(.*?)\n```", r"\1", new_file, flags=re.DOTALL)
+
+    # Trim leading and trailing whitespace from the entire content.
+    new_file = new_file.strip()
 
     return new_file


### PR DESCRIPTION
This PR addresses issue #959. In modify_file, trim new_file, and also strip out markdown code quotes if they exist. eg transform this:

```python
1 + 2
```

Into

1 + 2