### PR TITLE
Add terminal command

### DIFF
--- a/src/commands/command_terminal.py
+++ b/src/commands/command_terminal.py
@@ -1,0 +1,59 @@
+import subprocess
+from .command import Command
+from .state import State
+
+
+class Terminal(Command):
+    """
+    Class representing a Terminal command.
+    """
+
+    @classmethod
+    def name(cls) -> str:
+        return "Terminal"
+
+    @property
+    def terminal(self):
+        return True
+
+    def __init__(self, command_string: str):
+        self.command_string: str = command_string
+
+    @staticmethod
+    def schema() -> dict:
+        """
+        Returns the schema for the Terminal command.
+        """
+        return {
+            "name": "Terminal",
+            "description": "Execute a given string as a terminal command",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "command_string": {
+                        "type": "string",
+                        "description": "The terminal command to execute",
+                    }
+                },
+                "required": ["command_string"],
+            },
+        }
+
+    @staticmethod
+    def load_from_json(json_data: dict) -> "Terminal":
+        """
+        Loads the Terminal command from the provided json_data.
+        """
+        return Terminal(json_data["command_string"])
+
+    def execute(self, state: State) -> str:
+        """
+        Executes the Terminal command.
+        """
+        result = subprocess.run(
+            self.command_string, shell=True, capture_output=True, text=True
+        )
+        return result.stdout
+
+    def __str__(self):
+        return f"Function Called: Terminal command_string={self.command_string}"

--- a/src/commands/commands.py
+++ b/src/commands/commands.py
@@ -1,15 +1,16 @@
 # commands/commands.py
 
 from .command import Command
-from .command_think import Think
-from .command_verdict import Verdict
 from .command_files import Files
-from .command_replace_file import ReplaceFile
-from .command_search import Search
-from .command_delete_file import DeleteFile
 from .command_install_package import InstallPackage
 from .command_move_file import MoveFile
+from .command_replace_file import ReplaceFile
 from .command_replace_node import ReplaceNode
+from .command_search import Search
+from .command_delete_file import DeleteFile
+from .command_terminal import Terminal
+from .command_think import Think
+from .command_verdict import Verdict
 
 COMMANDS_CHECK = [Verdict, Files]
 
@@ -23,4 +24,5 @@ COMMANDS_GENERATE = [
     MoveFile,
     InstallPackage,
     ReplaceNode,
+    Terminal,
 ]


### PR DESCRIPTION
This PR addresses issue #965. Title: Add terminal command
Description: Add a new Command called command_terminal.py, which runs a given string on the command line. Use command_search.py as an example. Add the new command to commands.py.