### PR TITLE
Clarify upgrading packages

### DIFF
--- a/prompts/advice.txt
+++ b/prompts/advice.txt
@@ -8,3 +8,4 @@
 * When moving a function or class from one file to another, add imports to the old file to ensure that code can still read it, and also add imports to the new file for whatever it depends on.
 * When moving a string constant to a file, remember to remove the quotes around the string.
 * If no files exist yet, please create one.
+* If a package has been updated, you can assume it's on the latest version.

--- a/src/commands/command_install_package.py
+++ b/src/commands/command_install_package.py
@@ -5,7 +5,7 @@ from tools.pip import install_package
 
 class InstallPackage(Command):
     """
-    Class representing InstallPackage command.
+    Installs or updates a package to the latest version using pip.
     """
 
     @classmethod
@@ -48,13 +48,13 @@ class InstallPackage(Command):
 
     def execute(self, state: State):
         """
-        Executes the InstallPackage command.
+        Executes the InstallPackage command and ensures the package has been installed or updated and is on the latest version.
         """
         requirements_contents = install_package(self.tool)
 
         state.files["requirements.txt"] = requirements_contents
 
-        return f"Tool {self.tool} has been installed."
+        return f"Tool {self.tool} has been installed or updated and is on the latest version."
 
     def __str__(self):
         return f"Function Called: {self.name()} tool={self.tool}"


### PR DESCRIPTION
This PR addresses issue #982. Title: Clarify upgrading packages
Description: In the pip command, clarify in the description that it installs or updates a package to the latest version. The execute method should be updated to say "has been installed or updated and is on the latest version".

In advice.txt, add a line item that says "If a package has been updated, you can assume it's on the latest version".