### PR TITLE
Depends on advice

### DIFF
--- a/prompts/advice.txt
+++ b/prompts/advice.txt
@@ -9,3 +9,4 @@
 * When moving a string constant to a file, remember to remove the quotes around the string.
 * If no files exist yet, please create one.
 * If a package has been updated, you can assume it's on the latest version.
+* If depends on #{issue} is part of the task, you can assume that the other task has been successfully completed before you're seeing this task.


### PR DESCRIPTION
This PR addresses issue #986. Title: Depends on advice
Description: Add to advice.txt a line that reads:

"If depends on #{issue} is part of the task, you can assume that the other task has been successfully completed before you're seeing this task."