### PR TITLE
Make terminal command not terminal

### DIFF
--- a/src/commands/command_terminal.py
+++ b/src/commands/command_terminal.py
@@ -16,7 +16,12 @@ class Terminal(Command):
 
     @property
     def terminal(self):
-        return True
+        """
+        A property that indicates whether the command should terminate the sequence when executed.
+        This returns False as executing a command on the console does not necessarily mean
+        the end of the command sequence.
+        """
+        return False
 
     def __init__(self, command_string: str):
         self.command_string: str = command_string


### PR DESCRIPTION
This PR addresses issue #991. Title: Make terminal command not terminal
Description: command_terminal has a terminal property that returns true. This is actually in error - the command exists to run commands on the console, whereas the terminal property indicates whether the command should finish the sequence. 

Update command_terminal to return false for this property, and add a comment explaining the distinction.