### PR TITLE
Add target_dir to state

### DIFF
--- a/src/commands/command_terminal.py
+++ b/src/commands/command_terminal.py
@@ -1,4 +1,5 @@
 import subprocess
+import os
 from .command import Command
 from .state import State
 from tracing.trace import trace
@@ -57,12 +58,21 @@ class Terminal(Command):
         """
         Executes the Terminal command.
         """
-        trace(SYSTEM, f"Executing terminal command: {self.command_string}")
-        result = subprocess.run(
-            self.command_string, shell=True, capture_output=True, text=True
-        )
-        trace(SYSTEM, f"Terminal command output: {result.stdout}")
-        return result.stdout
+        original_dir = os.getcwd()
+        try:
+            if state.target_dir:
+                os.chdir(state.target_dir)
+            trace(SYSTEM, f"Executing terminal command: {self.command_string}")
+            result = subprocess.run(
+                self.command_string, shell=True, capture_output=True, text=True
+            )
+            trace(SYSTEM, f"Terminal command output: {result.stdout}")
+            return result.stdout
+        except Exception as e:
+            trace(SYSTEM, f"Error executing terminal command: {e}")
+            raise e
+        finally:
+            os.chdir(original_dir)
 
     def __str__(self):
         return f"Function Called: Terminal command_string={self.command_string}"

--- a/src/commands/loop.py
+++ b/src/commands/loop.py
@@ -45,8 +45,14 @@ def command_loop_iterate(state, system, command_classes):
     return (None, state)
 
 
-def command_loop(prompt: str, system: str, command_classes: list, files: dict = {}):
-    state = State(files)
+def command_loop(
+    prompt: str,
+    system: str,
+    command_classes: list,
+    files: dict = {},
+    target_dir: str = None,
+):
+    state = State(files, target_dir=target_dir)
     state.scratch = prompt
     exception_count = 0
 

--- a/src/commands/state.py
+++ b/src/commands/state.py
@@ -3,7 +3,8 @@ import copy
 
 
 class State:
-    def __init__(self, files_dict: Dict[str, str]):
+    def __init__(self, files_dict: Dict[str, str], target_dir: str = None):
         self.files: Dict[str, str] = copy.deepcopy(files_dict)
         self.original_files: Dict[str, str] = copy.deepcopy(files_dict)
         self.scratch: str = ""
+        self.target_dir: str = target_dir


### PR DESCRIPTION
This PR addresses issue #995. Title: Add target_dir to state
Description: Add target_dir as an optional string to State, and make it an optional parameter to command_loop.

In the Terminal command, execute the specified command in target_dir if it exists.