### PR TITLE
Clarify requirements.txt advice

### DIFF
--- a/prompts/advice.txt
+++ b/prompts/advice.txt
@@ -11,4 +11,4 @@
 * If a package has been updated, you can assume it's on the latest version.
 * If depends on #{issue} is part of the task, you can assume that the other task has been successfully completed before you're seeing this task.
 * For software versions represented with semver, x.y.z is newer than a.b.c if x > a, or if x == a and y > b, or if x == a and y == b then if z > c
-* Always use the install package command when installing versions. Never edit requirements.txt directly.
+* Always use the install package command when installing versions. Installing a package this way will modify requirements.txt, but ReplaceFile should not be used to modify it directly.


### PR DESCRIPTION
This PR addresses issue #1003. Title: Clarify requirements.txt advice
Description: In advice.txt, remove the "never edit requirements.txt directly" sentence. Replace it with: "Installing a package this way will modify requirements.txt, but ReplaceFile should not be used to modify it directly."