### PR TITLE
Move import advice into issue.txt

### DIFF
--- a/prompts/issue.txt
+++ b/prompts/issue.txt
@@ -8,4 +8,4 @@
 {{goal}}
 
 ### DETAILS ###
-{{details}}
+Imports should be relative to {{code_path}}, so {{code_path}}/cat/dog.py should be imported as 'cat.dog'

--- a/src/pipeline/issue.py
+++ b/src/pipeline/issue.py
@@ -65,15 +65,12 @@ OBJECTIVE:
 def apply_prompt_to_files(prompt: str, files: dict, target_dir: str = None) -> dict:
     old_files = files
     advice = generate_advice(prompt)
+    code_path = settings.CODE_PATH
     context = {
         "files": ", ".join(files.keys()),
         "advice": advice,
         "goal": prompt,
-        "details": "Imports should be relative to "
-        + settings.CODE_PATH
-        + ", so "
-        + settings.CODE_PATH
-        + "/cat/dog.py should be imported as 'cat.dog'",
+        "code_path": code_path,
     }
     prompt = load_prompt("issue", context)
     command, state = command_loop(


### PR DESCRIPTION
This PR addresses issue #1013. Title: Move import advice into issue.txt
Description: Move the import advice in "details" in apply_prompt_to_files into the issue.txt template by:

* Set "code_path" in context to settings.CODE_PATH
* Move the text generated in the function to the template