### PR TITLE
Add import advice to issue.txt

### DIFF
--- a/prompts/issue.txt
+++ b/prompts/issue.txt
@@ -9,3 +9,4 @@
 
 ### DETAILS ###
 Imports should be relative to {{code_path}}, so {{code_path}}/cat/dog.py should be imported as 'cat.dog'
+Always use absolute imports from the top level of the project. Never use relative imports.


### PR DESCRIPTION
This PR addresses issue #1015. Title: Add import advice to issue.txt
Description: In the details section of issue.txt, add a sentence that says:

"Always use absolute imports from the top level of the project. Never use relative imports."