### PR TITLE
Make synchronize_files_read recursive

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -11,7 +11,7 @@ def read_file(path: str) -> str:
 def add_line_numbers(file_contents: str) -> str:
     """Returns the file contents with line numbers added."""
     lines = file_contents.split("\n")
-    numbered_lines = [f"{idx+1}: {line}" for idx, line in enumerate(lines)]
+    numbered_lines = [f"{idx + 1}: {line}" for idx, line in enumerate(lines)]
     return "\n".join(numbered_lines)
 
 
@@ -30,7 +30,6 @@ def partition_by_predicate(sequence: list, predicate: callable) -> list:
     """
     result = []
     current_group = []
-
     for item in sequence:
         if predicate(item):
             if current_group:
@@ -39,10 +38,8 @@ def partition_by_predicate(sequence: list, predicate: callable) -> list:
             current_group.append(item)
         else:
             current_group.append(item)
-
     if current_group:
         result.append(current_group)
-
     return result
 
 
@@ -62,8 +59,9 @@ def annotate_with_line_numbers(content: str) -> str:
     """
     if not content:
         return "1: <blank line>"
-
-    annotated_lines = [f"{i+1}: {line}" for i, line in enumerate(content.splitlines())]
+    annotated_lines = [
+        f"{i + 1}: {line}" for i, line in enumerate(content.splitlines())
+    ]
     return "\n".join(annotated_lines)
 
 
@@ -83,7 +81,6 @@ def synchronize_files_write(target_dir, old_files, updated_files):
     """Writes the contents of updated_files to disk and removes files that no longer exist."""
     for k, v in updated_files.items():
         write_file(os.path.join(target_dir, k), v)
-
     deleted_files = [f for f in old_files.keys() if f not in updated_files]
     for f in deleted_files:
         os.remove(os.path.join(target_dir, f))
@@ -94,13 +91,16 @@ def synchronize_files_read(target_dir, old_files, updated_files):
     Copies file contents from the disk into updated_files. Removes entries from updated_files if they no longer exist on disk.
     This does not add new files that have been added to the disk.
     """
-    all_files_in_directory = os.listdir(target_dir)
-    for file_name_on_disk in all_files_in_directory:
-        file_path = os.path.join(target_dir, file_name_on_disk)
-        if os.path.isfile(file_path):
-            with open(file_path, "r", encoding="utf-8") as file:
-                updated_files[file_name_on_disk] = file.read()
-
+    for root, dirs, files in os.walk(target_dir):
+        for file_name_on_disk in files:
+            relative_path = os.path.relpath(
+                os.path.join(root, file_name_on_disk), target_dir
+            )
+            if relative_path in updated_files:
+                with open(
+                    os.path.join(root, file_name_on_disk), "r", encoding="utf-8"
+                ) as file:
+                    updated_files[relative_path] = file.read()
     files_not_found = set(old_files.keys()) - set(updated_files.keys())
     for file_name in files_not_found:
         updated_files.pop(file_name, None)


### PR DESCRIPTION
This PR addresses issue #1020. Title: Make synchronize_files_read recursive
Description: The function currently does not recurse into subdirectories. It should pull in all relevant files. But ignore files that aren't already part of updated_files.