### PR TITLE
Support relative file access

### DIFF
--- a/src/commands/command_files.py
+++ b/src/commands/command_files.py
@@ -35,7 +35,7 @@ class Files(Command):
         return False
 
     def __init__(self, files: list):
-        self.files: list = files
+        self.files: list = [file.lstrip("./") for file in files]
 
     @staticmethod
     def schema() -> dict:


### PR DESCRIPTION
This PR addresses issue #1019. Title: Support relative file access
Description: For command_files, if the files requested start with eg "./something.py" instead of "something.py", strip off the ./