### PR TITLE
Fix up gpt.py

### DIFF
--- a/src/gpt.py
+++ b/src/gpt.py
@@ -57,8 +57,8 @@ def gpt_query(
                 raise Exception("No functions returned")
             end_time = time.time()
             call_duration = end_time - start_time
-            tokens_in = completion["usage"]["prompt_tokens"]
-            tokens_out = completion["usage"]["completion_tokens"]
+            tokens_in = completion.usage.prompt_tokens
+            tokens_out = completion.usage.completion_tokens
             cprint(
                 f"Call took {call_duration:.1f}s, {tokens_in} tokens in, {tokens_out} tokens out",
                 "yellow",


### PR DESCRIPTION
This PR addresses issue #1023. Title: Fix up gpt.py
Description: 1) "function_call" is no longer a dict style property. use completion.choices[0].message.function_call.
2) Same for completion["usage"]["prompt_tokens"] and ["completion_tokens"] - just use .usage.prompt_tokens and .usage.completion_tokens respectively.