### PR TITLE
Trace stderr in command_terminal

### DIFF
--- a/src/commands/command_terminal.py
+++ b/src/commands/command_terminal.py
@@ -67,7 +67,8 @@ class Terminal(Command):
             result = subprocess.run(
                 self.command_string, shell=True, capture_output=True, text=True
             )
-            trace(SYSTEM, f"Terminal command output: {result.stdout}")
+            trace(SYSTEM, f"Terminal command stdout: {result.stdout}")
+            trace(SYSTEM, f"Terminal command stderr: {result.stderr}")
             return result.stdout
         except Exception as e:
             trace(SYSTEM, f"Error executing terminal command: {e}")


### PR DESCRIPTION
This PR addresses issue #1033. Title: Trace stderr in command_terminal
Description: In command_terminal.py, also trace strerr as well as stdout when running a command.