### PR TITLE
Save the class of the last returned command in State

### DIFF
--- a/src/commands/loop.py
+++ b/src/commands/loop.py
@@ -33,6 +33,7 @@ def command_loop_iterate(state, system, command_classes):
     output = command.execute(state)
     state.scratch += "\n" + str(command)
     state.scratch += "\n" + output
+    state.last_command = command.__class__
     exception_count = 0
     return None, state
 

--- a/src/commands/state.py
+++ b/src/commands/state.py
@@ -8,3 +8,4 @@ class State:
         self.original_files: Dict[str, str] = copy.deepcopy(files_dict)
         self.scratch: str = ""
         self.target_dir: str = target_dir
+        self.last_command = None


### PR DESCRIPTION
This PR addresses issue #1037. Title: Save the class of the last returned command in State
Description: In state.py, add a last_command field which defaults to None. It should store the class of the last command. In loop.py, set this field as appropriate.