### PR TITLE
Move summarize prompt out of code

### DIFF
--- a/prompts/summarize.txt
+++ b/prompts/summarize.txt
@@ -1,0 +1,11 @@
+Summarize the following source code, extracting classes, functions and constants by extracting the definitions into the following format:
+
+# One line comment that describes the purpose of this class
+class Test
+   fn class_method(self)
+
+# One line comment that describes the purpose of this function
+fn a_function(arg1,arg2)
+
+# One line comment that describes the purpose of this constant
+CONSTANT_NAME

--- a/src/tools/summarize.py
+++ b/src/tools/summarize.py
@@ -1,21 +1,10 @@
 from gpt import cached_gpt_query
 from gpt import GPT_4
-
-SYSTEM_SUMMARIZE = """
-Summarize the following source code, extracting classes, functions and constants by extracting the definitions into the following format:
-
-# One line comment that describes the purpose of this class
-class Test
-   fn class_method(self)
-
-# One line comment that describes the purpose of this function
-fn a_function(arg1,arg2)
-
-# One line comment that describes the purpose of this constant
-CONSTANT_NAME
-"""
+from utilities.prompts import load_prompt
 
 
 def summarize(source_code: str) -> str:
-    result = cached_gpt_query(source_code, system=SYSTEM_SUMMARIZE, model=GPT_4)
+    result = cached_gpt_query(
+        source_code, system=load_prompt("summarize.txt"), model=GPT_4
+    )
     return result


### PR DESCRIPTION
This PR addresses issue #1040. Title: Move summarize prompt out of code
Description: Move the prompt from summarize.py to a summarize.txt file in the prompts directory. Use load_prompt to load it in.