### PR TITLE
Add two new lines before listing each file in command_files

### DIFF
--- a/src/commands/command_files.py
+++ b/src/commands/command_files.py
@@ -80,7 +80,7 @@ class Files(Command):
             if file in state.files:
                 content_with_tabs = replace_spaces_with_tabs(state.files[file])
                 annotated_content = annotate_with_line_numbers(content_with_tabs)
-                result += f"{file}: \n{annotated_content}"
+                result += f"\n\n{file}: \n{annotated_content}"
             else:
-                result += f"File {file} does not exist.\n"
-        return result
+                result += f"\n\nFile {file} does not exist.\n"
+        return result.strip()


### PR DESCRIPTION
This PR addresses issue #1045. Title: Add two new lines before listing each file in command_files
Description: None