### PR TITLE
Update relative advice

### DIFF
--- a/prompts/issue.txt
+++ b/prompts/issue.txt
@@ -9,4 +9,4 @@
 
 ### DETAILS ###
 Imports should be relative to {{code_path}}, so {{code_path}}/cat/dog.py should be imported as 'cat.dog'
-Always use absolute imports from the top level of the project. Never use relative imports.
+Never use a relative import that reaches into a parent directory, like ..cat.dog.


### PR DESCRIPTION
This PR addresses issue #1048. Title: Update relative advice
Description: Update the sentences in advice.txt that say to always use absolute imports. Replace them with a sentence that says never use a relative import that reaches into a parent directory, like ..cat.dog.