### PR TITLE
Add information dict to State

### DIFF
--- a/src/commands/loop.py
+++ b/src/commands/loop.py
@@ -28,6 +28,7 @@ def command_loop_iterate(state, system, command_classes):
         command_classes = [
             cmd_cls for cmd_cls in command_classes if cmd_cls != state.last_command
         ]
+    state.scratch += "\n\n" + state.render_information()
     result = gpt_query(state.scratch + "\n", system, extract_schemas(command_classes))
     if isinstance(result, str):
         return result, state

--- a/src/commands/state.py
+++ b/src/commands/state.py
@@ -9,3 +9,10 @@ class State:
         self.scratch: str = ""
         self.target_dir: str = target_dir
         self.last_command = None
+        self.information: Dict[str, str] = {}
+
+    def render_information(self) -> str:
+        rendered_info = []
+        for key, value in self.information.items():
+            rendered_info.append(f"{key}:\n{value}")
+        return "\n\n".join(rendered_info)


### PR DESCRIPTION
This PR addresses issue #1054. Title: Add information dict to State
Description: Add an information dict to State, which has keys/values of strings.

Add a function to render the dict, by looping over the k/v pairs and rendering:

key1:
value1

key2:
value2 


etc

In command_loop_iterate, render the dict and pass it into gpt_query after scratch.