### PR TITLE
Put files in information

### DIFF
--- a/src/commands/command_files.py
+++ b/src/commands/command_files.py
@@ -75,12 +75,12 @@ class Files(Command):
         """
         Executes the Files command.
         """
-        result = ""
+        messages = []
         for file in self.files:
             if file in state.files:
                 content_with_tabs = replace_spaces_with_tabs(state.files[file])
-                annotated_content = annotate_with_line_numbers(content_with_tabs)
-                result += f"\n\n{file}: \n{annotated_content}"
+                state.information[file] = content_with_tabs
+                messages.append(f"File {file} has been added to context")
             else:
-                result += f"\n\nFile {file} does not exist.\n"
-        return result.strip()
+                messages.append(f"File {file} does not exist.")
+        return "\n".join(messages)


### PR DESCRIPTION
This PR addresses issue #1056. Title: Put files in information
Description: In the Files command, when executing, instead of putting the filename and contents of the file in the return value of the function, instead add the filename as a key and the contents of the file as a value to the information portion of State. For the return value, instead just say "File (name) has been added to context"