### PR TITLE
Add settings file

### DIFF
--- a/duopoly.yaml
+++ b/duopoly.yaml
@@ -1,0 +1,2 @@
+reviewers:
+ - "reitzensteinm"

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ PyJWT==2.7.0
 pylint==2.17.4
 PyNaCl==1.5.0
 pytest==7.3.1
-PyYAML==6.0
+PyYAML==6.0.1
 requests==2.30.0
 smmap==5.0.0
 sniffio==1.3.0

--- a/src/settings.py
+++ b/src/settings.py
@@ -1,6 +1,16 @@
+import yaml
+
+
 class Settings:
     def __init__(self):
         self.reviewers = []
+
+    def load_from_yaml(self, filepath="duopoly.yaml"):
+        with open(filepath, "r") as yamlfile:
+            data = yaml.safe_load(yamlfile)
+
+        if "reviewers" in data:
+            self.reviewers = data["reviewers"]
 
 
 REPOSITORY_PATH = ["reitzensteinm/duopoly", "reitzensteinm/duopoly-website"]


### PR DESCRIPTION
This PR addresses issue #1063. Title: Add settings file
Description: Add a duopoly.yaml settings file to the root directory, containing a reviewers property, a string array containing "reitzensteinm"

Add a function in settings.py to load this yaml file into a Settings class instance. Missing fields should retain the default properties of the Settings class.