### PR TITLE
Add print_analysis function

### DIFF
--- a/src/website/analysis.py
+++ b/src/website/analysis.py
@@ -1,5 +1,31 @@
 from git import Repo
-from datetime import datetime
+from datetime import datetime, timedelta
+import pprint
+
+
+def print_analysis(repo_dir):
+    pprinter = pprint.PrettyPrinter(indent=4)
+
+    one_month_ago = datetime.now() - timedelta(days=30)
+    three_months_ago = datetime.now() - timedelta(days=90)
+    beginning_of_time = datetime.min
+
+    # Last month statistics
+    last_month_stats = generate_statistics(repo_dir, (one_month_ago, datetime.now()))
+    print("Last month statistics:")
+    pprinter.pprint(last_month_stats)
+
+    # Last three months statistics
+    last_three_months_stats = generate_statistics(
+        repo_dir, (three_months_ago, datetime.now())
+    )
+    print("Last three months statistics:")
+    pprinter.pprint(last_three_months_stats)
+
+    # All-time statistics
+    all_time_stats = generate_statistics(repo_dir, (beginning_of_time, datetime.now()))
+    print("All-time statistics:")
+    pprinter.pprint(all_time_stats)
 
 
 def generate_statistics(repo_dir, time_range):
@@ -15,9 +41,15 @@ def generate_statistics(repo_dir, time_range):
     - 'ai': The count of AI-written commits.
     - 'human': The count of human-written commits.
     - 'ai_percentage': The percentage of commits written by AI.
+    - 'last_human_commit_date': The date of the last human commit.
     """
     ai_email = "133977416+duopoly@users.noreply.github.com"
-    commit_counts = {"ai": 0, "human": 0, "ai_percentage": 0.0}
+    commit_counts = {
+        "ai": 0,
+        "human": 0,
+        "ai_percentage": 0.0,
+        "last_human_commit_date": None,
+    }
 
     # Open the repository
     repo = Repo(repo_dir)
@@ -28,17 +60,23 @@ def generate_statistics(repo_dir, time_range):
     # Fetch commits within the time range
     commits = list(repo.iter_commits(since=start_time, until=end_time))
 
+    last_human_commit_date = None
     for commit in commits:
         # Check if the commit is written by the AI
         if commit.committer.email == ai_email:
             commit_counts["ai"] += 1
         else:
             commit_counts["human"] += 1
+            last_human_commit_date = commit.committed_datetime
 
     total_commits = commit_counts["ai"] + commit_counts["human"]
 
     # Calculate the percentage of AI-written commits if there are any commits
     if total_commits > 0:
         commit_counts["ai_percentage"] = (commit_counts["ai"] / total_commits) * 100
+
+    # Set the date of the last human commit
+    if last_human_commit_date:
+        commit_counts["last_human_commit_date"] = last_human_commit_date
 
     return commit_counts


### PR DESCRIPTION
This PR addresses issue #1082. Title: Add print_analysis function
Description: In analysis.py, add a print_analysis function that runs generate_statistics for the last one month, three months, and since the beginning, pretty printing the results and time period for each

In generate_statistics, add to the return value a property that is the date of last human commit.