### PR TITLE
Call print_analysis on command line

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -8,11 +8,10 @@ from pipeline.issue import process_issue
 import repo
 from evals.evals import process_evals
 from tracing.trace import create_trace, bind_trace, trace
-from website.analysis import generate_statistics
+from website.analysis import print_analysis
 from tracing.tags import EXCEPTION
-from datetime import datetime, timedelta
+from datetime import datetime
 import os
-import pprint
 import ast
 import astor
 import settings
@@ -111,15 +110,14 @@ def main():
         required=False,
         default=None,
     )
-    parser.add_argument("--analyse", action="store_true", help="Activate analysis mode")
+    parser.add_argument(
+        "--analysis", action="store_true", help="Activate analysis mode"
+    )
     args = parser.parse_args()
 
-    if args.analyse:
-        end_date = datetime.now()
-        start_date = end_date - timedelta(days=30)
+    if args.analysis:
         repo_dir = os.getcwd()
-        statistics = generate_statistics(repo_dir, (start_date, end_date))
-        pprint.pprint(statistics)
+        print_analysis(repo_dir)
         sys.exit(0)
 
     if args.evals:


### PR DESCRIPTION
This PR addresses issue #1084. Title: Call print_analysis on command line
Description: When the --analysis flag is passed in, call print_analysis instead of the current calculation and printing of statistics.