### PR TITLE
Fix up readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,11 @@ the [second commit](https://github.com/reitzensteinm/duopoly/commit/7646e1be5a28
 
 ### Status
 
-🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 100% commits AI written last month
-
+🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩 100% commits AI written last month
 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟥 97% commits AI written last three months
-
 🟩🟩🟩🟩🟩🟩🟩🟩🟥🟥 84% commits AI written all time
 
-Last human commit: 10th September, 2023
+**Last human commit: 10th September, 2023**
 
 💰 OpenAI GPT-4 Turbo Cost: Approximately $2 per commit
 


### PR DESCRIPTION
This PR addresses issue #1090. Title: Fix up readme
Description: The progress bar for 100% has 11 icons in it. Also remove the spaces between the three progress bars, and make the Last human commit line bold.