### PR TITLE
Add the ability to select version with run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Check if a git tag is provided as a command-line argument and checkout that tag before running the script
+if [ ! -z "$1" ]; then
+	git checkout "$1"
+	echo "Checked out to tag $1"
+fi
+
 # Check if traces/ directory exists. If it does, delete it.
 if [ -d "traces/" ]; then
 	rm -rf traces/


### PR DESCRIPTION
This PR addresses issue #1098. Title: Add the ability to select version with run.sh
Description: Add an optional parameter to run.sh which specifies a release to checkout, defined by a tag. 

Eg: ./run.sh v0.0.1