### PR TITLE
Change terminal colour

### DIFF
--- a/src/tracing/render.py
+++ b/src/tracing/render.py
@@ -5,9 +5,7 @@ TAG_COLOR_MAPPING = {
     "gpt-input": {"background": "#000000", "border": "#808080", "text": "#2DE864"},
     "gpt-output": {"background": "#000000", "border": "#808080", "text": "#A3E8FA"},
     "exception": {"background": "#000000", "border": "#FF0000", "text": "#FF9698"},
-    "system": {"background": "#FFFFFF", "border": "#000000", "text": "#A9A9A9"},
-    # Add tag to color mapping here
-    # Format: 'tag': {'background': 'color', 'border': 'color', 'text': 'color'}
+    "system": {"background": "#000000", "border": "#000000", "text": "#A9A9A9"},
 }
 
 


### PR DESCRIPTION
This PR addresses issue #1112. Title: Change terminal colour
Description: The system TAG_COLOUR_MAPPING should instead have a pure black background.