### PR TITLE
Add thread local Settings

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -1,4 +1,7 @@
 import yaml
+import threading
+
+_thread_local_settings = threading.local()
 
 
 class Settings:
@@ -11,6 +14,18 @@ class Settings:
 
         if "reviewers" in data:
             self.reviewers = data["reviewers"]
+
+
+def get_settings():
+    if hasattr(_thread_local_settings, "settings"):
+        return _thread_local_settings.settings
+    return settings
+
+
+def apply_settings(yaml_path):
+    instance = Settings()
+    instance.load_from_yaml(yaml_path)
+    _thread_local_settings.settings = instance
 
 
 REPOSITORY_PATH = ["reitzensteinm/duopoly", "reitzensteinm/duopoly-website"]


### PR DESCRIPTION
This PR addresses issue #1110. Title: Add thread local Settings
Description: Add a thread local override to settings.py.

Add get_settings(), which returns the thread local variable if it exists, otherwise the settings variable.

Add apply_settings(), which takes a path to a yaml file on disk. It should load the settings, and set the thread local variable.