### PR TITLE
Fix file stripping

### DIFF
--- a/src/commands/command_files.py
+++ b/src/commands/command_files.py
@@ -1,4 +1,3 @@
-# command_files.py
 from commands.command import Command
 from commands.state import State
 from utils import annotate_with_line_numbers
@@ -35,7 +34,9 @@ class Files(Command):
         return False
 
     def __init__(self, files: list):
-        self.files: list = [file.lstrip("./") for file in files]
+        self.files: list = [
+            (file[2:] if file.startswith("./") else file) for file in files
+        ]
 
     @staticmethod
     def schema() -> dict:


### PR DESCRIPTION
This PR addresses issue #1151. Title: Fix file stripping
Description: The Files command is incorrectly turning ".gitignore" into "gitignore". It should turn "./a" into "a", but should leave ".a" as "a".