### PR TITLE
Add original file to replace_file

### DIFF
--- a/src/tools/replace_file.py
+++ b/src/tools/replace_file.py
@@ -3,7 +3,6 @@ from utilities.prompts import load_prompt
 import re
 
 SYSTEM_REPLACE_THINK = load_prompt("replace_think")
-
 SYSTEM_REPLACE = load_prompt("replace")
 
 
@@ -12,16 +11,16 @@ def modify_file(original_file, instructions, context="", file_name=None):
         f"### THINKING FOR {file_name} ###" if file_name else "### THINKING ###"
     )
     new_file_text = f"### NEW FILE {file_name} ###" if file_name else "### NEW FILE ###"
-
-    instructions = f"### CONTEXT ###\n{context}\n### INSTRUCTIONS ###\n{instructions}\n### ORIGINAL FILE ###\n(see context)\n{thinking_text}"
+    instructions = f"""### CONTEXT ###
+{context}
+### INSTRUCTIONS ###
+{instructions}
+### ORIGINAL FILE ###
+{original_file}
+{thinking_text}"""
     thinking = gpt_query(instructions, SYSTEM_REPLACE_THINK)
     instructions = f"{instructions}\n{thinking}\n{new_file_text}"
     new_file = gpt_query(instructions, SYSTEM_REPLACE)
-
-    # Remove Markdown code quotes.
-    new_file = re.sub(r"```[\w]*\n(.*?)\n```", r"\1", new_file, flags=re.DOTALL)
-
-    # Trim leading and trailing whitespace from the entire content.
+    new_file = re.sub("```[\\w]*\\n(.*?)\\n```", "\\1", new_file, flags=re.DOTALL)
     new_file = new_file.strip()
-
     return new_file


### PR DESCRIPTION
This PR addresses issue #1148. Title: Add original file to replace_file
Description: Add original_file to the instructions in modify_file. Currently, it just says "see context".