### PR TITLE
Add can_repeat property to Command

### DIFF
--- a/src/commands/command.py
+++ b/src/commands/command.py
@@ -2,10 +2,7 @@ import json
 from tools.replace_file import modify_file
 from commands.state import State
 from utils import annotate_with_line_numbers, format_python_code
-from black import (
-    FileMode,
-    format_str,
-)  # Added import for Black's format_str and FileMode
+from black import FileMode, format_str
 
 """
 Example Command schema:
@@ -31,6 +28,9 @@ class Command:
     """
     Class representing a command.
     """
+
+    def __init__(self):
+        self.can_repeat = True
 
     @classmethod
     def name(cls) -> str:

--- a/src/commands/command_think.py
+++ b/src/commands/command_think.py
@@ -1,5 +1,3 @@
-# src/commands/command_think.py
-
 from commands.command import Command
 from commands.state import State
 
@@ -8,6 +6,8 @@ class Think(Command):
     """
     Class representing a Think command.
     """
+
+    can_repeat = False
 
     @classmethod
     def name(cls) -> str:


### PR DESCRIPTION
This PR addresses issue #1144. Title: Add can_repeat property to Command
Description: Add a can_repeat property on Command, which should default to True. Think should have can_repeat as False.