### PR TITLE
Move trace time to create_trace

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -10,7 +10,6 @@ from evals.evals import process_evals
 from tracing.trace import create_trace, bind_trace, trace
 from website.analysis import print_analysis
 from tracing.tags import EXCEPTION
-from datetime import datetime
 import os
 import ast
 import astor
@@ -63,8 +62,7 @@ def process_repository(dry_run=False, issue_name=None, repository="") -> None:
             return
         if issue_name is None or issue_name in issue.title:
             for attempt in range(MAX_RETRIES):
-                current_time = time.strftime("%Y%m%d_%H%M%S")
-                trace_instance = create_trace(f"{issue.title}_{current_time}")
+                trace_instance = create_trace(issue.title)
                 bind_trace(trace_instance)
                 try:
                     process_issue(issue, dry_run)

--- a/src/tracing/trace.py
+++ b/src/tracing/trace.py
@@ -16,7 +16,10 @@ class TraceData:
 
 class Trace:
     def __init__(self, name: str):
-        self.name = name
+        from datetime import datetime
+
+        current_time = datetime.now().strftime("%Y%m%d_%H%M%S")
+        self.name = f"{current_time}_{name}"
         self.trace_data = []
 
     def add_trace_data(self, tag, trace, tokens: Optional[Tuple[int, int]] = None):


### PR DESCRIPTION
This PR addresses issue #1129. Title: Move trace time to create_trace
Description: In main.py, current_time is calculated and appended to the name for create_trace. 

Instead of doing this here, do this in the body of create_trace, so all traces have the time appended.

In addition, place the time at the start, so the trace names will alphabetically sort.