### PR TITLE
Move max workers to Settings

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -87,7 +87,7 @@ def process_repository(dry_run=False, issue_name=None, repository="") -> None:
     if dry_run:
         process_open_issue(open_issues[0])
         return
-    with ThreadPoolExecutor(max_workers=5) as executor:
+    with ThreadPoolExecutor(max_workers=settings.MAX_WORKERS) as executor:
         results = executor.map(process_open_issue, open_issues)
     for result in results:
         pass

--- a/src/settings.py
+++ b/src/settings.py
@@ -3,6 +3,8 @@ import threading
 
 _thread_local_settings = threading.local()
 
+MAX_WORKERS = 10
+
 
 class Settings:
     def __init__(self):


### PR DESCRIPTION
This PR addresses issue #1125. Title: Move max workers to Settings
Description: Move the max_workers property in main.py to settings.py as a global file constant, MAX_WORKERS. Reference this variable instead of it being hardcoded. Make it 10.