### PR TITLE
Fix run.sh behaviour

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,17 +1,22 @@
 #!/bin/bash
 
-# Check if a git tag is provided as a command-line argument and checkout that tag before running the script
-if [ ! -z "$1" ]; then
-	git checkout "$1"
-	echo "Checked out to tag $1"
-else
-	git checkout main
-	echo "Checked out to main branch"
+# First, determine if we are in a detached HEAD state
+if ! git symbolic-ref --quiet --short HEAD; then
+    # We are in a detached HEAD state
+    if [ ! -z "$1" ]; then
+        # A tag is provided, checkout this tag
+        git checkout "$1"
+        echo "Checked out to tag $1"
+    else
+        # No tag provided, checkout main branch
+        git checkout main
+        echo "Checked out to main branch"
+    fi
 fi
 
 # Check if traces/ directory exists. If it does, delete it.
 if [ -d "traces/" ]; then
-	rm -rf traces/
+    rm -rf traces/
 fi
 
 # Create a new traces/ directory
@@ -22,20 +27,20 @@ nohup python3 -m http.server -d traces/ 8000 > /dev/null 2>&1 &
 
 while true
 do
-	# Update git repo
-	git pull
-	
-	# Install requirements
-	pip3 install -q -r requirements.txt
-	
-	# Run the python script
-	python3 src/main.py
-	
-	echo -e '\033[95mexecution successful\033[0m'
-	
-	# Sleep for 100 hours
-	sleep 360000
-	
-	# Exit the loop
-	break
+    # Update git repo
+    git pull
+
+    # Install requirements
+    pip3 install -q -r requirements.txt
+
+    # Run the python script
+    python3 src/main.py
+
+    echo -e '\033[95mexecution successful\033[0m'
+
+    # Sleep for 100 hours
+    sleep 360000
+
+    # Exit the loop
+    break
 done


### PR DESCRIPTION
This PR addresses issue #1160. Title: Fix run.sh behaviour
Description: run.sh when the repo is on a detached head doesn't reset to main (or the version tag) properly. Please fix this.