### PR TITLE
Remove Files from COMMANDS_CHECK

### DIFF
--- a/src/commands/commands.py
+++ b/src/commands/commands.py
@@ -11,7 +11,7 @@ from .command_think import Think
 from .command_verdict import Verdict
 from .command_revert import Revert
 
-COMMANDS_CHECK = [Verdict, Files, Terminal]
+COMMANDS_CHECK = [Verdict, Terminal]
 COMMANDS_GENERATE = [
     Think,
     Verdict,


### PR DESCRIPTION
This PR addresses issue #1146. Title: Remove Files from COMMANDS_CHECK
Description: Remove the Files command from the COMMANDS_CHECK array in commands.py.

Depends on #1163
