### PR TITLE
Change function from indexing to an attribute in gpt_query_tools

### DIFF
--- a/src/gpt.py
+++ b/src/gpt.py
@@ -135,7 +135,7 @@ def gpt_query_tools(
                 raise e
             time.sleep(backoff)
             backoff *= 2
-    function_calls = [call["function"] for call in tool_calls]
+    function_calls = [call.function for call in tool_calls]
     trace(GPT_OUTPUT, function_calls, (tokens_in, tokens_out))
     cprint(f"Function calls result: {function_calls}", "cyan")
     return function_calls


### PR DESCRIPTION
This PR addresses issue #1178. Title: Change function from indexing to an attribute in gpt_query_tools
Description: In gpt_query_tools in gpt.py, accessing the function attribute is incorrectly done via indexing.