### PR TITLE
Add test for gpt_query_tools

### DIFF
--- a/src/test_gpt.py
+++ b/src/test_gpt.py
@@ -15,3 +15,43 @@ ADD: dict = {
     },
     "returns": {"type": "integer", "description": "The sum of the two input integers."},
 }
+
+
+def test_gpt_query_tools() -> None:
+    """
+    Test the gpt_query_tools function with the purpose of being a calculator.
+    The test should simulate adding two pairs of numbers together using separate ADD operations,
+    and expect two results back simultaneously.
+
+    Assure that two FunctionCalls with expected values are returned from gpt_query_tools.
+    The test is currently ignored and should be enabled after the concerned code is implemented.
+
+    Arguments:
+    None
+
+    Returns:
+    None
+    """
+    # The test is ignored for now. Uncomment the below code to enable it.
+    #
+    # add_function = {
+    #     "name": "add",
+    #     "arguments": {
+    #         "x": 1,
+    #         "y": 2
+    #     }
+    # }
+    # add_function2 = {
+    #     "name": "add",
+    #     "arguments": {
+    #         "x": 3,
+    #         "y": 4
+    #     }
+    # }
+    # system_message = 'This tool is a calculator for adding numbers.'
+    # prompt = 'Please add 1 and 2 together. Also, add 3 and 4.'
+    # expected_function_calls = [add_function, add_function2]
+    # function_calls_returned = gpt_query_tools(prompt, system_message, [ADD])
+    #
+    # assert function_calls_returned == expected_function_calls, f"Expected function calls to be {expected_function_calls}, but got {function_calls_returned}"
+    pass


### PR DESCRIPTION
This PR addresses issue #1179. Title: Add test for gpt_query_tools
Description: In test_gpt.py, add a test for gpt_query_tools. Add a system message saying that the purpose is to be a calculator. Add a prompt that involves adding two numbers together, twice. They have to be separate sums that don't depend on each other, since we want two results back simultaneously. For the available functions, use the ADD dict.

A Function call object is returned, that looks like this:

class Function:
  name: str
  arguments: Dict[str,Any]

Assert that two functions are returned from gpt_query_tools with the expected values.

Mark the test as ignored for now.