### PR TITLE
Move MAX_WORKERS into Settings object

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -85,7 +85,9 @@ def process_repository(dry_run=False, issue_name=None, repository="") -> None:
     if dry_run:
         process_open_issue(open_issues[0])
         return
-    with ThreadPoolExecutor(max_workers=settings.MAX_WORKERS) as executor:
+    with ThreadPoolExecutor(
+        max_workers=settings.get_settings().max_workers
+    ) as executor:
         results = executor.map(process_open_issue, open_issues)
     for result in results:
         pass

--- a/src/settings.py
+++ b/src/settings.py
@@ -3,28 +3,42 @@ import threading
 
 _thread_local_settings = threading.local()
 
-MAX_WORKERS = 10
-
 
 class Settings:
     def __init__(self):
         self.reviewers = []
+        self.max_workers = 10
 
     def load_from_yaml(self, filepath="duopoly.yaml"):
         with open(filepath, "r") as yamlfile:
             data = yaml.safe_load(yamlfile)
-
         if "reviewers" in data:
             self.reviewers = data["reviewers"]
 
 
-def get_settings():
+def get_settings() -> Settings:
+    """Retrieve the current settings instance.
+
+    Returns:
+            Settings: The current thread-local Settings instance.
+
+    This function fetches the Settings object associated with the thread-local
+    storage. If it does not exist, it returns the global Settings instance.
+    """
     if hasattr(_thread_local_settings, "settings"):
         return _thread_local_settings.settings
     return settings
 
 
-def apply_settings(yaml_path):
+def apply_settings(yaml_path: str) -> None:
+    """Apply settings from a yaml file to the current Settings instance.
+
+    Args:
+            yaml_path (str): The path to the yaml file from which to load settings.
+
+    This function creates a new Settings instance, loads settings from the
+    specified yaml file, and stores it in the thread-local storage.
+    """
     instance = Settings()
     instance.load_from_yaml(yaml_path)
     _thread_local_settings.settings = instance
@@ -41,5 +55,4 @@ PR_REVIEWER_USERNAME = "reitzensteinm"
 MAX_INPUT_CHARS = 48000
 PYLINT_RETRIES = 1
 CHECK_OPEN_PR = False
-
 settings = Settings()


### PR DESCRIPTION
This PR addresses issue #1184. Title: Move MAX_WORKERS into Settings object
Description: In settings.py, move MAX_WORKERS into the Settings object, as a max_workers member variable. All accesses to settings should be via get_settings(). Don't add a getter for the member variable.