### PR TITLE
Move DO_QUALITY_CHECKS to Settings

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -136,6 +136,8 @@ def main() -> None:
         help="Enable the use of the new OpenAI tools API",
     )
     args = parser.parse_args()
+    settings.get_settings().do_quality_checks = args.quality_checks
+    settings.get_settings().use_tools = args.use_tools
     settings.PARSED_ARGS = vars(args)
     if args.analysis:
         repo_dir = os.getcwd()

--- a/src/settings.py
+++ b/src/settings.py
@@ -11,7 +11,8 @@ class Settings:
         self.reviewers = []
         self.max_workers = 10
         self.MAX_INPUT_CHARS = 48000
-        self.use_tools: bool = False  # New field indicating whether to use tools.
+        self.use_tools: bool = False
+        self.do_quality_checks: bool = True
 
     def load_from_yaml(self, filepath: str = "duopoly.yaml") -> None:
         """Load settings from the specified YAML file.
@@ -30,7 +31,7 @@ class Settings:
         Args:
                         do_quality_checks (bool): Indicate whether to perform quality checks.
         """
-        self.DO_QUALITY_CHECKS = do_quality_checks
+        self.do_quality_checks = do_quality_checks
 
 
 def get_settings() -> Settings:


### PR DESCRIPTION
This PR addresses issue #1193. Title: Move DO_QUALITY_CHECKS to Settings
Description: Move DO_QUALITY_CHECKS to the Settings object, like max_workers. Access to this should be via get_settings()