### PR TITLE
Refactor PR reviewer logic

### DIFF
--- a/src/repo.py
+++ b/src/repo.py
@@ -49,15 +49,23 @@ def push_local_branch_to_origin(branch_id: str, target_dir: str = os.getcwd()) -
 
 
 def create_pull_request(repo_name: str, branch_id: str, title: str, body: str) -> None:
-    """Creates a pull request on GitHub with the specified details."""
-    from settings import REQUEST_REVIEW_FOR_PRS, PR_REVIEWER_USERNAME
+    """Creates a pull request on GitHub with the specified details and requests reviews based on settings.
+
+    Args:
+            repo_name (str): The name of the target repository.
+            branch_id (str): The id of the branch for which the pull request is created.
+            title (str): The title of the pull request.
+            body (str): The body description of the pull request.
+    """
+    from settings import get_settings
 
     api_key = os.environ["GITHUB_API_KEY"]
     g = Github(api_key)
     repo = g.get_repo(repo_name)
     pr = repo.create_pull(title=title, body=body, head=branch_id, base="main")
-    if REQUEST_REVIEW_FOR_PRS:
-        pr.create_review_request(reviewers=[PR_REVIEWER_USERNAME])
+    settings = get_settings()
+    if settings.reviewers:
+        pr.create_review_request(reviewers=settings.reviewers)
 
 
 def find_approved_prs(repo_name: str) -> List[int]:

--- a/src/settings.py
+++ b/src/settings.py
@@ -10,7 +10,12 @@ class Settings:
         self.max_workers = 10
         self.MAX_INPUT_CHARS = 48000
 
-    def load_from_yaml(self, filepath="duopoly.yaml"):
+    def load_from_yaml(self, filepath: str = "duopoly.yaml") -> None:
+        """Load settings from the specified YAML file.
+
+        Args:
+            filepath (str): The path to the YAML settings file to load.
+        """
         with open(filepath, "r") as yamlfile:
             data = yaml.safe_load(yamlfile)
         if "reviewers" in data:
@@ -21,7 +26,7 @@ def get_settings() -> Settings:
     """Retrieve the current settings instance.
 
     Returns:
-            Settings: The current thread-local Settings instance.
+        Settings: The current thread-local Settings instance.
 
     This function fetches the Settings object associated with the thread-local
     storage. If it does not exist, it returns the global Settings instance.
@@ -32,13 +37,13 @@ def get_settings() -> Settings:
 
 
 def apply_settings(yaml_path: str) -> None:
-    """Apply settings from a yaml file to the current Settings instance.
+    """Apply settings from a YAML file to the current Settings instance.
 
     Args:
-            yaml_path (str): The path to the yaml file from which to load settings.
+        yaml_path (str): The path to the YAML file from which to load settings.
 
     This function creates a new Settings instance, loads settings from the
-    specified yaml file, and stores it in the thread-local storage.
+    specified YAML file, and stores it in the thread-local storage.
     """
     instance = Settings()
     instance.load_from_yaml(yaml_path)
@@ -51,8 +56,6 @@ GITIGNORE_PATH = ".gitignore"
 ADMIN_USERS = ["reitzensteinm", "Zylatis", "atroche"]
 TOKEN_LIMIT = 40000
 DO_QUALITY_CHECKS = True
-REQUEST_REVIEW_FOR_PRS = True
-PR_REVIEWER_USERNAME = "reitzensteinm"
 PYLINT_RETRIES = 1
 CHECK_OPEN_PR = False
 settings = Settings()


### PR DESCRIPTION
This PR addresses issue #1194. Title: Refactor PR reviewer logic
Description: Instead of using the REQUEST_REVIEW_FOR_PRS constant, as well as the PR_REVIEWER_USERNAME, use the reviewers list via get_settings(). Request multiple reviews if appropriate, and none if the array is empty. Delete the now unused constants.