### PR TITLE
Add apply_commandline_overrides to Settings

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -130,6 +130,10 @@ def main() -> None:
         default=False,
     )
     args = parser.parse_args()
+
+    # Apply command-line argument overrides to settings
+    settings.get_settings().apply_commandline_overrides(args.quality_checks)
+
     if args.analysis:
         repo_dir = os.getcwd()
         print_analysis(repo_dir)

--- a/src/settings.py
+++ b/src/settings.py
@@ -14,12 +14,20 @@ class Settings:
         """Load settings from the specified YAML file.
 
         Args:
-            filepath (str): The path to the YAML settings file to load.
+                filepath (str): The path to the YAML settings file to load.
         """
         with open(filepath, "r") as yamlfile:
             data = yaml.safe_load(yamlfile)
         if "reviewers" in data:
             self.reviewers = data["reviewers"]
+
+    def apply_commandline_overrides(self, do_quality_checks: bool) -> None:
+        """Override class variables based on command line arguments.
+
+        Args:
+                do_quality_checks (bool): Indicate whether to perform quality checks.
+        """
+        self.DO_QUALITY_CHECKS = do_quality_checks
 
 
 def get_settings() -> Settings:


### PR DESCRIPTION
This PR addresses issue #1199. Title: Add apply_commandline_overrides to Settings
Description: In the Settings class, add a method to override the class variables based on parameters passed via the command line in main.py. For now, this is just the do quality checks option.