### PR TITLE
Add release to changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+### v0.0.2 (WIP)
+
+Per project settings, read in via duopoly.yaml
+Reduced context size by not sending duplicate files
+Use STYLE file if it exists
+
 ### v0.0.1
 
 Initial release.


### PR DESCRIPTION
This PR addresses issue #1205. Title: Add release to changelog
Description: Add a v0.0.2 release to the changelog, with a (WIP) marker next to the version name.

Add these changes (following the existing formatting of the file): 

* Per project settings, read in via duopoly.yaml
* Reduced context size by not sending duplicate files
* Use STYLE file if it exists