### PR TITLE
Support multiple functions in command_loop_iterate

### DIFF
--- a/src/commands/loop.py
+++ b/src/commands/loop.py
@@ -35,15 +35,16 @@ def command_loop_iterate(state: State, system: str, command_classes: list) -> tu
     Processes a command loop iteration.
 
     This function processes a single iteration of the command loop, handling the execution
-    of a command based on the GPT-generated response and updates the state accordingly.
+    of a command based on the GPT-generated responses and updates the state accordingly.
+    The function supports processing multiple results, but currently, GPT queries return a single result.
 
     Args:
-                    state (State): The current state of the command loop.
-                    system (str): The GPT-3 system being used.
-                    command_classes (list): A list of available command classes.
+                            state (State): The current state of the command loop.
+                            system (str): The GPT-3 system being used.
+                            command_classes (list): A list of available command classes.
 
     Returns:
-                    tuple: A tuple containing execution result and the updated state.
+                            tuple: A tuple containing execution results and the updated state.
     """
     if (
         state.last_command
@@ -64,13 +65,15 @@ def command_loop_iterate(state: State, system: str, command_classes: list) -> tu
         )
         if isinstance(result, str):
             return result, state
-        command = parse_gpt_response(command_classes, result)
-        if command.terminal:
-            return command, state
-        output = command.execute(state)
-        state.scratch += "\n" + str(command)
-        state.scratch += "\n" + output
-        state.last_command = command
+        results = [result]
+        for result in results:
+            command = parse_gpt_response(command_classes, result)
+            if command.terminal:
+                return command, state
+            output = command.execute(state)
+            state.scratch += "\n" + str(command)
+            state.scratch += "\n" + output
+            state.last_command = command
         return None, state
     except Exception as e:
         state.scratch += "\nException thrown calling command! " + str(e)


### PR DESCRIPTION
This PR addresses issue #1211. Title: Support multiple functions in command_loop_iterate
Description: Add the ability to process multiple results at a time in command_loop_iterate.

For now, gpt_query just returns one result, so create a results variable that just has the single result in a list. 

Modify the rest of command_loop_iterate to loop over each result in the list.