### PR TITLE
Throw exception in replace_node if the node does not exist.

### DIFF
--- a/src/tools/code.py
+++ b/src/tools/code.py
@@ -2,7 +2,21 @@ import ast
 import astor
 
 
-def replace_node(src_code, target_node, new_code):
+def replace_node(src_code: str, target_node: str, new_code: str) -> str:
+    """
+    Replace the specified node in the source code with new code.
+
+    The function searches the Abstract Syntax Tree (AST) for the target node. If found, it is replaced with the parsed contents of new_code.
+
+    Args:
+            src_code (str): The source code to search.
+            target_node (str): The name of the node to replace.
+            new_code (str): The new code to insert in place of the old node.
+
+    Returns:
+            str: The source code after the replacement has been made.
+    """
+    node_found = False
     tree = ast.parse(src_code)
     for node in ast.walk(tree):
         if isinstance(node, (ast.FunctionDef, ast.ClassDef, ast.Assign)) and (
@@ -12,6 +26,7 @@ def replace_node(src_code, target_node, new_code):
             and isinstance(node.targets[0], ast.Name)
             and node.targets[0].id == target_node
         ):
+            node_found = True
             new_tree = ast.parse(new_code)
             new_node = new_tree.body[0]
             if isinstance(node, (ast.FunctionDef, ast.ClassDef)):
@@ -30,4 +45,8 @@ def replace_node(src_code, target_node, new_code):
                 if isinstance(new_node, ast.Assign):
                     node.targets[0].id = new_node.targets[0].id
                     node.value = new_node.value
+    if not node_found:
+        raise ValueError(
+            f"Node '{target_node}' does not exist in the supplied source code."
+        )
     return astor.to_source(tree)


### PR DESCRIPTION
This PR addresses issue #1207. Title: Throw exception in replace_node if the node does not exist.
Description: Just throw the exception in the helper function, for now.