### PR TITLE
Fix Settings arg parsing

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -136,7 +136,7 @@ def main() -> None:
         help="Enable the use of the new OpenAI tools API",
     )
     args = parser.parse_args()
-    settings.get_settings().apply_commandline_overrides(args.quality_checks)
+    settings.PARSED_ARGS = vars(args)
     if args.analysis:
         repo_dir = os.getcwd()
         print_analysis(repo_dir)

--- a/src/settings.py
+++ b/src/settings.py
@@ -1,5 +1,6 @@
 import yaml
 import threading
+from typing import Optional, Any
 
 _thread_local_settings = threading.local()
 
@@ -67,3 +68,11 @@ DO_QUALITY_CHECKS = True
 PYLINT_RETRIES = 1
 CHECK_OPEN_PR = False
 settings = Settings()
+PARSED_ARGS: Optional[Any] = None
+"""A dictionary of the parsed command line arguments.
+
+This constant is intended to be set in main.py with the actual parsed arguments
+from the command line after argparse processing. It is initialized as None and
+should be of type Optional[dict] to allow for type checking and to indicate that
+it may not yet be set at the time of module import.
+"""


### PR DESCRIPTION
This PR addresses issue #1209. Title: Fix Settings arg parsing
Description: Add a PARSED_ARGS constant to settings.py, and set it in main.py. Don't call apply_commandline_overrides in main.py.