### PR TITLE
Call apply_commandline_overrides in settings.py

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -2,6 +2,11 @@ import yaml
 import threading
 from typing import Optional, Any
 
+PARSED_ARGS: Optional[Any] = None
+"""A dictionary of the parsed command line arguments.
+
+This constant is intended to be set in main.py with the actual parsed arguments from the command line after argparse processing. It is initialized as None and should be of type Optional[dict] to allow for type checking and to indicate that it may not yet be set at the time of module import.
+"""
 _thread_local_settings = threading.local()
 
 
@@ -10,30 +15,36 @@ class Settings:
         """Initialize the Settings with the default configuration values.
 
         This constructor sets up the Settings object with default values such as an empty list of reviewers,
-        maximum number of workers, maximum input characters, and the use of tools flag. It also adds
-        the new quality_checks field, defaulting to True.
+        maximum number of workers, maximum input characters, and the use of tools flag. It ensures command line arguments
+        override these settings by calling apply_commandline_overrides at the end.
         """
         self.reviewers = []
         self.max_workers = 10
         self.MAX_INPUT_CHARS = 48000
         self.use_tools: bool = False
         self.quality_checks: bool = True
+        self.apply_commandline_overrides()
 
     def load_from_yaml(self, filepath: str = "duopoly.yaml") -> None:
-        """Load settings from the specified YAML file.
+        """Load settings from the specified YAML file and ensure command line arguments override the loaded settings.
 
         Args:
                 filepath (str): The path to the YAML settings file to load.
+
+        This method loads configuration values from a YAML file and ensures that afterwards,
+        command line parameters take priority by calling apply_commandline_overrides.
         """
         with open(filepath, "r") as yamlfile:
             data = yaml.safe_load(yamlfile)
         if "reviewers" in data:
             self.reviewers = data["reviewers"]
+        self.apply_commandline_overrides()
 
     def apply_commandline_overrides(self) -> None:
         """Override certain settings values based on PARSED_ARGS.
 
-        This function accesses the global PARSED_ARGS and utilizes it to determine if quality checks should be performed.
+        This function accesses the global PARSED_ARGS and utilizes it to determine if certain settings like quality checks
+        should be performed.
         """
         global PARSED_ARGS
         self.DO_QUALITY_CHECKS = (
@@ -47,7 +58,8 @@ def get_settings() -> Settings:
     Returns:
             Settings: The current thread-local Settings instance.
 
-    This function fetches the Settings object associated with the thread-local storage. If it does not exist, it returns the global Settings instance.
+    This function fetches the Settings object associated with the thread-local storage.
+    If it does not exist, it returns the global Settings instance.
     """
     if hasattr(_thread_local_settings, "settings"):
         return _thread_local_settings.settings
@@ -60,7 +72,8 @@ def apply_settings(yaml_path: str) -> None:
     Args:
             yaml_path (str): The path to the YAML file from which to load settings.
 
-    This function creates a new Settings instance, loads settings from the specified YAML file, and stores it in the thread-local storage.
+    This function creates a new Settings instance, loads settings from the specified YAML file,
+    and stores it in the thread-local storage.
     """
     instance = Settings()
     instance.load_from_yaml(yaml_path)
@@ -76,8 +89,3 @@ DO_QUALITY_CHECKS = True
 PYLINT_RETRIES = 1
 CHECK_OPEN_PR = False
 settings = Settings()
-PARSED_ARGS: Optional[Any] = None
-"""A dictionary of the parsed command line arguments.
-
-This constant is intended to be set in main.py with the actual parsed arguments from the command line after argparse processing. It is initialized as None and should be of type Optional[dict] to allow for type checking and to indicate that it may not yet be set at the time of module import.
-"""


### PR DESCRIPTION
This PR addresses issue #1224. Title: Call apply_commandline_overrides in settings.py
Description: In the Settings class, apply_commandline_overrides should be called at the end of load_from_yaml, as well as __init__, so that commandline overrides always take priority.

Move PARSED_ARGS to the top of the file to ensure it exists when the function is called.