### PR TITLE
Add tools to changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 Per project settings, read in via duopoly.yaml
 Reduced context size by not sending duplicate files
 Use STYLE file if it exists
+Experimental compatibility with OpenAI's new Tools API
 
 ### v0.0.1
 


### PR DESCRIPTION
This PR addresses issue #1226. Title: Add tools to changelog
Description: Add a line to the changelog for v0.0.2:

Experimental compatibility with OpenAI's new Tools API