### PR TITLE
Clean up apply_commandline_overrides

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -50,13 +50,8 @@ class Settings:
         """
         global PARSED_ARGS
         if PARSED_ARGS:
-            self.do_quality_checks = PARSED_ARGS.get(
-                "quality_checks", self.quality_checks
-            )
+            self.quality_checks = PARSED_ARGS.get("quality_checks", self.quality_checks)
             self.use_tools = PARSED_ARGS.get("use_tools", self.use_tools)
-        else:
-            self.do_quality_checks = self.quality_checks
-            self.use_tools = self.use_tools
 
 
 def get_settings() -> Settings:


### PR DESCRIPTION
This PR addresses issue #1233. Title: Clean up apply_commandline_overrides
Description: * There's no use to have an else branch if there is no PARSED_ARGS
* do_quality_checks should not be used - the field is called quality_checks