### PR TITLE
Add v0.0.3 to changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### v0.0.3 (WIP)
+
+- Now configured for continuous operation.
+
 ### v0.0.2
 
 - Per project settings, read in via duopoly.yaml


### PR DESCRIPTION
This PR addresses issue #1264. Title: Add v0.0.3 to changelog
Description: Add v0.0.3 to changelog, with a (WIP) after the title, and one feature:

Now configured for continuous operation.