### PR TITLE
Make Quality Checks None by default

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -118,7 +118,7 @@ def main() -> None:
         action="store_true",
         help="Activate quality checks mode",
         required=False,
-        default=False,
+        default=None,
     )
     parser.add_argument(
         "--use-tools",


### PR DESCRIPTION
This PR addresses issue #1276. Title: Make Quality Checks None by default
Description: The default value for --quality-checks should be None. In load_from_yaml, handle the value being None by not doing the override.