### PR TITLE
Reset IssueState when prompt changes

### DIFF
--- a/src/pipeline/issue.py
+++ b/src/pipeline/issue.py
@@ -147,16 +147,16 @@ def prepare_branch(issue: Issue, dry_run: bool) -> str:
 def process_issue(issue: Issue, dry_run: bool) -> None:
     """Processes a single issue by setting up a branch, applying prompts, running checks, and creating pull requests.
 
-    Checks the retry count before processing and skips the issue with a message if it exceeds max_issue_retries obtained from get_settings().
+    Checks the retry count before processing and resets it if the formatted prompt has changed. Skips the issue with a message if it exceeds max_issue_retries obtained from get_settings().
     Increases the retry count after an open PR check if no open PR was found, and does not process the issue if the author is not marked as an admin,
     if the issue is not open, or if there is already an open PR for the issue.
 
     Params:
-                    issue (Issue): The issue to be processed.
-                    dry_run (bool): If true, does not conduct any writes or branch modifications.
+            issue (Issue): The issue to be processed.
+            dry_run (bool): If true, does not conduct any writes or branch modifications.
 
     Returns:
-                    None
+            None
     """
     if issue.author not in settings.ADMIN_USERS:
         return
@@ -168,6 +168,11 @@ def process_issue(issue: Issue, dry_run: bool) -> None:
         return
     issue_state = IssueState.retrieve_by_id(issue.id)
     settings_instance = settings.get_settings()
+    formatted_prompt = f"Title: {issue.title}\nDescription: {issue.description}"
+    if issue_state.prompt != formatted_prompt:
+        issue_state.retry_count = 0
+        issue_state.prompt = formatted_prompt
+    issue_state.store()
     if issue_state.retry_count > settings_instance.max_issue_retries:
         print(
             f"\x1b[91mSkipping processing of issue {issue.number} due to too many attempts\x1b[0m"
@@ -176,7 +181,6 @@ def process_issue(issue: Issue, dry_run: bool) -> None:
     issue_state.retry_count += 1
     issue_state.store()
     target_dir = prepare_branch(issue, dry_run)
-    formatted_prompt = f"Title: {issue.title}\nDescription: {issue.description}"
     duopoly_path = os.path.join(target_dir, "duopoly.yaml")
     if os.path.exists(duopoly_path):
         settings.apply_settings(duopoly_path)


### PR DESCRIPTION
This PR addresses issue #1284. Title: Reset IssueState when prompt changes
Description: In process_issue, if formatted_prompt differs from the prompt field of the IssueState instance, reset retry_count to 0, and set the prompt field of IssueState to be the new formatted_prompt. Do this before checking the retry_count to check whether to skip the issue.