### PR TITLE
Clean up settings

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -21,50 +21,18 @@ class Settings:
         """
         self.reviewers: List[str] = []
         self.max_workers: int = 10
-        self.MAX_INPUT_CHARS: int = 48000
+        self.max_input_chars: int = 48000
         self.use_tools: bool = False
         self.quality_checks: bool = True
         self.max_issue_retries: int = 2
         self.apply_commandline_overrides()
-
-    def load_from_yaml(self, filepath: str = "duopoly.yaml") -> None:
-        """Load settings from a YAML file and apply command line overrides.
-
-        Args:
-                        filepath (str): The path to the YAML settings file to load.
-
-        This method updates the instance with settings from the YAML file at `filepath` and applies overrides.
-        """
-        with open(filepath, "r") as yamlfile:
-            data = yaml.safe_load(yamlfile)
-        if "reviewers" in data:
-            self.reviewers = data["reviewers"]
-        if "quality_checks" in data and data["quality_checks"] is not None:
-            self.quality_checks = data["quality_checks"]
-        self.apply_commandline_overrides()
-
-    def apply_commandline_overrides(self) -> None:
-        """Override settings based on parsed command line arguments.
-
-        Utilizes the global PARSED_ARGS to set settings for quality checks and use of tools, if specified.
-        """
-        global PARSED_ARGS
-        if PARSED_ARGS:
-            if (
-                "quality_checks" in PARSED_ARGS
-                and PARSED_ARGS["quality_checks"] is not None
-            ):
-                self.quality_checks = PARSED_ARGS.get(
-                    "quality_checks", self.quality_checks
-                )
-            self.use_tools = PARSED_ARGS.get("use_tools", self.use_tools)
 
 
 def get_settings() -> Settings:
     """Retrieve the current thread-local Settings instance or the global instance if not set.
 
     Returns:
-        Settings: The current thread-local Settings instance or the global Settings instance.
+            Settings: The current thread-local Settings instance or the global Settings instance.
 
     This function fetches the Settings object associated with the thread-local storage.
     If it does not exist, it returns the global Settings instance.
@@ -78,7 +46,7 @@ def apply_settings(yaml_path: str) -> None:
     """Create a new Settings instance from a YAML file and store it in thread-local storage.
 
     Args:
-        yaml_path (str): The path to the YAML file from which to load settings.
+            yaml_path (str): The path to the YAML file from which to load settings.
 
     This function creates a new Settings instance, loads settings from the specified YAML file,
     and stores it in the thread-local storage.
@@ -92,7 +60,6 @@ REPOSITORY_PATH = ["reitzensteinm/duopoly", "reitzensteinm/duopoly-website"]
 CODE_PATH = "src"
 GITIGNORE_PATH = ".gitignore"
 ADMIN_USERS = ["reitzensteinm", "Zylatis", "atroche"]
-TOKEN_LIMIT = 40000
 PYLINT_RETRIES = 1
 CHECK_OPEN_PR = True
 settings = Settings()


### PR DESCRIPTION
This PR addresses issue #1290. Title: Clean up settings
Description: Make max_input_chars lower case in settings.py. 

Also, remove the TOKEN_LIMIT constant.