### PR TITLE
Fix Quality Checks default

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -115,10 +115,10 @@ def main() -> None:
     parser.add_argument("--context", action="store_true", help="Activate context mode")
     parser.add_argument(
         "--quality-checks",
-        action="store_true",
-        help="Activate quality checks mode",
+        type=str,
+        help="Specify the quality checks",
         required=False,
-        default=False,
+        default=None,
     )
     parser.add_argument(
         "--use-tools",


### PR DESCRIPTION
This PR addresses issue #1298. Title: Fix Quality Checks default
Description: --quality-checks should have None as the default, indicating it wasn't passed through