### PR TITLE
Make render_information more clearly display files

### DIFF
--- a/src/commands/state.py
+++ b/src/commands/state.py
@@ -12,7 +12,13 @@ class State:
         self.information: Dict[str, str] = {}
 
     def render_information(self) -> str:
+        """
+        Formats the information dictionary into a string for display.
+
+        Returns:
+                A string representing the formatted information.
+        """
         rendered_info = []
         for key, value in self.information.items():
-            rendered_info.append(f"{key}:\n{value}")
+            rendered_info.append(f"*** {key} ***\n{value}")
         return "\n\n".join(rendered_info)

--- a/src/pipeline/project.py
+++ b/src/pipeline/project.py
@@ -1,3 +1,6 @@
+from typing import List
+
+
 class Project:
     def __init__(self, path: str):
         """Initialize the Project with a path and an empty list of code paths.


### PR DESCRIPTION
This PR addresses issue #1302. Title: Make render_information more clearly display files
Description: In render_information, modify the lines generated to look like this:

### REQUESTED FILES ###

*** key ***
value

*** key ***
value