### PR TITLE
Add line numbers for files requested via command_files

### DIFF
--- a/src/commands/command_files.py
+++ b/src/commands/command_files.py
@@ -75,12 +75,20 @@ class Files(Command):
     def execute(self, state: State) -> str:
         """
         Executes the Files command.
+        Adds line numbers to the file contents.
+
+        Args:
+                state (State): The current state object.
+
+        Returns:
+                str: Messages indicating the status of each file.
         """
         messages = []
         for file in self.files:
             if file in state.files:
                 content_with_tabs = replace_spaces_with_tabs(state.files[file])
-                state.information[file] = content_with_tabs
+                annotated_content = annotate_with_line_numbers(content_with_tabs)
+                state.information[file] = annotated_content
                 messages.append(f"File {file} has been added to context")
             else:
                 messages.append(f"File {file} does not exist.")

--- a/src/pipeline/project.py
+++ b/src/pipeline/project.py
@@ -1,3 +1,6 @@
+from typing import List
+
+
 class Project:
     def __init__(self, path: str):
         """Initialize the Project with a path and an empty list of code paths.


### PR DESCRIPTION
This PR addresses issue #1303. Title: Add line numbers for files requested via command_files
Description: In command_files, any requested files should have line numbers added to them with add_line_numbers