### PR TITLE
Make render_information more clearly display files

### DIFF
--- a/src/commands/state.py
+++ b/src/commands/state.py
@@ -12,7 +12,13 @@ class State:
         self.information: Dict[str, str] = {}
 
     def render_information(self) -> str:
+        """
+        Renders information as a string where every key is surrounded by '***' and displayed above its value.
+
+        Returns:
+                str: The formatted string containing keys and values.
+        """
         rendered_info = []
         for key, value in self.information.items():
-            rendered_info.append(f"{key}:\n{value}")
+            rendered_info.append(f"*** {key} ***\n{value}")
         return "\n\n".join(rendered_info)


### PR DESCRIPTION
This PR addresses issue #1302. Title: Make render_information more clearly display files
Description: In render_information, modify the lines generated to look like this:

### REQUESTED FILES ###

*** key ***
value

*** key ***
value