### PR TITLE
Use files system with command_files

### DIFF
--- a/src/commands/command_files.py
+++ b/src/commands/command_files.py
@@ -75,7 +75,7 @@ class Files(Command):
     def execute(self, state: State) -> str:
         """
         Executes the Files command.
-        Adds line numbers to the file contents.
+        Calls add_file on the state object for each file.
 
         Args:
                 state (State): The current state object.
@@ -86,9 +86,7 @@ class Files(Command):
         messages = []
         for file in self.files:
             if file in state.files:
-                content_with_tabs = replace_spaces_with_tabs(state.files[file])
-                annotated_content = annotate_with_line_numbers(content_with_tabs)
-                state.information[file] = annotated_content
+                state.add_file(file)
                 messages.append(f"File {file} has been added to context")
             else:
                 messages.append(f"File {file} does not exist.")


### PR DESCRIPTION
This PR addresses issue #1309. Title: Use files system with command_files
Description: Depends on #1308 

When executing the Files command, instead of adding the filenames and contents to the information in State, instead simply call add_file with the filename. State will take care of the rest.