### PR TITLE
Don't check comments in get_linked_issue

### DIFF
--- a/src/repo.py
+++ b/src/repo.py
@@ -368,20 +368,9 @@ def get_linked_issue(repo_name: str, pr_id: int) -> Optional[Issue]:
     repo = g.get_repo(repo_name)
     pr = repo.get_pull(pr_id)
     linked_issue_number = None
-
-    # Check PR body for linked Issue
-    match = re.search(r"#(\d+)", pr.body)
+    match = re.search("#(\\d+)", pr.body)
     if match:
         linked_issue_number = int(match.group(1))
-    else:
-        # Check PR comments for linked Issue if none found in body
-        comments = pr.get_issue_comments()
-        for comment in comments:
-            match = re.search(r"#(\d+)", comment.body)
-            if match:
-                linked_issue_number = int(match.group(1))
-                break
-
     if linked_issue_number:
         issue = repo.get_issue(linked_issue_number)
         return Issue(


### PR DESCRIPTION
This PR addresses issue #1321. Title: Don't check comments in get_linked_issue
Description: The function should not check comments in search of a linked issue.