### PR TITLE
Delete branch and close issue when squash merging

### DIFF
--- a/src/repo.py
+++ b/src/repo.py
@@ -338,23 +338,22 @@ def list_commit_titles_and_authors(target_dir: str = os.getcwd()) -> List[str]:
     return commit_info_list
 
 
-def merge_with_squash(repo_name: str, pr_number: int, body: str) -> bool:
-    """Perform a squash merge on a pull request with a specified body and PR title as the commit title.
-
-    Args:
-            repo_name (str): The name of the repository.
-            pr_number (int): The number of the pull request to merge.
-            body (str): The body to use in the commit message.
-
-    Returns:
-            bool: True if the pull request was successfully merged, False if it could not be merged.
+def merge_with_squash(repo_name: str, pr_number: int, commit_message: str) -> bool:
+    """
+    Perform a squash merge on a pull request with a specified commit message, delete the branch, and close the issue if the merge was successful.
+    The 'repo_name' argument specifies the repository name, 'pr_number' is the pull request number, and 'commit_message' is used in the final commit.
+    Returns True if the pull request was successfully merged, the branch and issue are closed; otherwise, returns False.
     """
     api_key = os.environ["GITHUB_API_KEY"]
     g = Github(api_key)
     repo = g.get_repo(repo_name)
     pr = repo.get_pull(pr_number)
     try:
-        pr.merge(merge_method="squash", commit_title=pr.title, commit_message=body)
+        pr.merge(
+            merge_method="squash", commit_title=pr.title, commit_message=commit_message
+        )
+        close_issue_by_title(repo_name, pr.title)
+        delete_branch_after_merge(g, repo_name, pr.head.ref)
         return True
     except Exception as e:
         print(f"Failed to squash merge PR: {pr_number} - {str(e)}")


### PR DESCRIPTION
This PR addresses issue #1336. Title: Delete branch and close issue when squash merging
Description: In merge_with_squash, delete the branch and close the issue if the merge was successful. See merge_with_rebase_if_possible for an example