### PR TITLE
Add initial_files to IssueState

### DIFF
--- a/src/pipeline/issue_state.py
+++ b/src/pipeline/issue_state.py
@@ -1,3 +1,4 @@
+from typing import Optional, Dict
 from utilities.cache import read, write
 
 
@@ -5,33 +6,36 @@ class IssueState:
     """Represents the state of an issue with a retry count and an associated prompt.
 
     Args:
-            id (int): The identifier of the issue.
+                    id (int): The identifier of the issue.
+                    initial_files (Optional[Dict[str, str]]): A dictionary mapping filenames to their contents, defaults to None if not provided.
 
     Returns:
-            IssueState: An instance representing the issue state.
+                    IssueState: An instance representing the issue state with the given id and initial_files.
 
     """
 
-    def __init__(self, id: int):
-        """Initialize the IssueState with an ID, a retry count set to zero, and an empty prompt.
+    def __init__(self, id: int, initial_files: Optional[Dict[str, str]] = None):
+        """Initialize the IssueState with an ID, a retry count set to zero, an empty prompt, and initial files mapping.
 
         Args:
-                id (int): The identifier of the issue.
+                        id (int): The identifier of the issue.
+                        initial_files (Optional[Dict[str, str]]): A dictionary mapping filenames to their contents, defaults to None if not provided.
 
         """
         self.id = id
         self.retry_count: int = 0
         self.prompt: str = ""
+        self.initial_files: Optional[Dict[str, str]] = initial_files
 
     @staticmethod
     def retrieve_by_id(id: int) -> "IssueState":
         """Retrieve the issue state by id directly if it exists, or create and store a new one if not found.
 
         Args:
-                id (int): The identifier of the issue.
+                        id (int): The identifier of the issue.
 
         Returns:
-                IssueState: The retrieved or newly created issue state.
+                        IssueState: The retrieved or newly created issue state.
 
         """
         try:
@@ -45,7 +49,7 @@ class IssueState:
         """Store the current issue state.
 
         Returns:
-                None
+                        None
         """
         write(f"issue-{self.id}", self)
 
@@ -53,7 +57,7 @@ class IssueState:
         """Return a string representation of the issue state.
 
         Returns:
-                str: The string representation of the issue state.
+                        str: The string representation of the issue state.
 
         """
         return str(self.__dict__)


### PR DESCRIPTION
This PR addresses issue #1350. Title: Add initial_files to IssueState
Description: Add an initial_files property on IssueState, which is a dict mapping filename to file contents. By default it should be None. 