### PR TITLE
Add a max_loop_length to Settings

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -9,14 +9,20 @@ This constant is intended to be set in main.py with the actual parsed arguments 
 """
 _thread_local_settings = threading.local()
 
+MAX_LOOP_LENGTH: int = 15
+"""The maximum length allowed for loops in the program's settings context.
+
+This constant represents the upper limit on the number of iterations a loop within the application is allowed to execute.
+"""
+
 
 class Settings:
     def __init__(self) -> None:
-        """Initialize the Settings with default configuration values including reviewers, workers, input chars, tools, quality checks, and issue retries.
+        """Initialize the Settings with default configuration values including reviewers, workers, input chars, tools, quality checks, issue retries, and max loop length.
 
         This constructor sets up the Settings object with default values such as an empty list of reviewers (list),
-        a maximum number of workers (int), maximum input characters (int), flags for use of tools (bool), and quality checks (bool),
-        and a maximum number of issue retries (int, defaulting to 2).
+        a maximum number of workers (int), maximum input characters (int), flags for use of tools (bool), quality checks (bool),
+        a maximum number of issue retries (int, defaulting to 2), and maximum loop length (int, defaulting to MAX_LOOP_LENGTH).
         Command line arguments can override these settings by call to apply_commandline_overrides at the end.
         """
         self.reviewers: List[str] = []
@@ -25,13 +31,14 @@ class Settings:
         self.use_tools: bool = False
         self.quality_checks: bool = True
         self.max_issue_retries: int = 2
+        self.max_loop_length: int = MAX_LOOP_LENGTH
         self.apply_commandline_overrides()
 
     def load_from_yaml(self, filepath: str = "duopoly.yaml") -> None:
         """Load settings from a YAML file and apply command line overrides.
 
         Args:
-                        filepath (str): The path to the YAML settings file to load.
+            filepath (str): The path to the YAML settings file to load.
 
         This method updates the instance with settings from the YAML file at `filepath` and applies overrides.
         """


### PR DESCRIPTION
This PR addresses issue #1356. Title: Add a max_loop_length to Settings
Description: Add a field to Settings, max_loop_length. Initialise it with the constant 15.