### PR TITLE
Add initial_files to IssueState

### DIFF
--- a/src/pipeline/issue_state.py
+++ b/src/pipeline/issue_state.py
@@ -1,27 +1,31 @@
+from typing import Dict, Optional
 from utilities.cache import read, write
 
 
 class IssueState:
-    """Represents the state of an issue with a retry count and an associated prompt.
+    """Represents the state of an issue with a retry count, an associated prompt, and an optional mapping of filenames to their contents at the initial state.
 
     Args:
             id (int): The identifier of the issue.
+            initial_files (Optional[Dict[str, str]]): A dictionary mapping filenames to file contents for the issue's initial state, defaulting to None.
 
     Returns:
             IssueState: An instance representing the issue state.
 
     """
 
-    def __init__(self, id: int):
-        """Initialize the IssueState with an ID, a retry count set to zero, and an empty prompt.
+    def __init__(self, id: int, initial_files: Optional[Dict[str, str]] = None):
+        """Initialize the IssueState with an ID, a retry count set to zero, an empty prompt, and optional initial files.
 
         Args:
                 id (int): The identifier of the issue.
+                initial_files (Optional[Dict[str, str]]): A dictionary mapping filenames to file contents for the issue's initial state, defaulting to None.
 
         """
         self.id = id
         self.retry_count: int = 0
         self.prompt: str = ""
+        self.initial_files: Optional[Dict[str, str]] = initial_files
 
     @staticmethod
     def retrieve_by_id(id: int) -> "IssueState":


### PR DESCRIPTION
This PR addresses issue #1350. Title: Add initial_files to IssueState
Description: Add an initial_files property on IssueState, which is a dict mapping filename to file contents. By default it should be None. 