### PR TITLE
Add a max_loop_length to Settings

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -25,13 +25,18 @@ class Settings:
         self.use_tools: bool = False
         self.quality_checks: bool = True
         self.max_issue_retries: int = 2
+        self.max_loop_length: int = 15
+        """An integer specifying the maximum length for loops within the system.
+
+        The default value is set to 15 and it determines how many times a loop can iterate before being terminated to prevent infinite looping.
+        """
         self.apply_commandline_overrides()
 
     def load_from_yaml(self, filepath: str = "duopoly.yaml") -> None:
         """Load settings from a YAML file and apply command line overrides.
 
         Args:
-                        filepath (str): The path to the YAML settings file to load.
+            filepath (str): The path to the YAML settings file to load.
 
         This method updates the instance with settings from the YAML file at `filepath` and applies overrides.
         """


### PR DESCRIPTION
This PR addresses issue #1356. Title: Add a max_loop_length to Settings
Description: Add a field to Settings, max_loop_length. Initialise it with the constant 15.