### PR TITLE
Add load_from_yaml for Project

### DIFF
--- a/src/pipeline/project.py
+++ b/src/pipeline/project.py
@@ -1,4 +1,5 @@
 from typing import List
+import yaml
 
 
 class Project:
@@ -10,3 +11,18 @@ class Project:
         """
         self.path = path
         self.code_paths: List[str] = []
+
+    def load_from_yaml(self, filepath: str = "duopoly.yaml") -> None:
+        """Load project-specific settings like code paths from a 'project' subsection of a YAML file.
+
+        Args:
+                filepath (str): The path to the YAML file that contains the project settings.
+
+        This method updates the instance with settings from the 'project' subsection of the YAML file at `filepath`.
+        """
+        with open(filepath, "r") as yamlfile:
+            data = yaml.safe_load(yamlfile)
+        if "project" in data:
+            project_data = data["project"]
+            if "code_paths" in project_data:
+                self.code_paths = project_data["code_paths"]


### PR DESCRIPTION
This PR addresses issue #1370. Title: Add load_from_yaml for Project
Description: Add a load_from_yaml for Project, similar to the one from Settings. Only load code_paths for now.

Load all settings from a "project" category in the yaml file.