### PR TITLE
Run load_from_yaml on Project in constructor

### DIFF
--- a/src/pipeline/project.py
+++ b/src/pipeline/project.py
@@ -1,16 +1,22 @@
 from typing import List
 import yaml
+import os
 
 
 class Project:
     def __init__(self, path: str):
-        """Initialize the Project with a path and an empty list of code paths.
+        """Initialize the Project with a path, an empty list of code paths, and load settings from 'duopoly.yaml' if it exists.
 
         Args:
                 path: A string representing the path to the project.
+
+        During initialization, if a 'duopoly.yaml' file exists in the project path, it attempts to load settings from it.
         """
         self.path = path
         self.code_paths: List[str] = []
+        duopoly_yaml_path = os.path.join(self.path, "duopoly.yaml")
+        if os.path.exists(duopoly_yaml_path):
+            self.load_from_yaml(duopoly_yaml_path)
 
     def load_from_yaml(self, filepath: str = "duopoly.yaml") -> None:
         """Load project-specific settings like code paths from a 'project' subsection of a YAML file.


### PR DESCRIPTION
This PR addresses issue #1384. Title: Run load_from_yaml on Project in constructor
Description: After Project has been constructed, run load_from_yaml on the "duopoly.yaml" file in the project's directory - if it exists.