### PR TITLE
Add function to emoji a comment

### DIFF
--- a/src/repo.py
+++ b/src/repo.py
@@ -447,3 +447,20 @@ def add_comment_to_issue_or_pr(
     repo = g.get_repo(repo_name)
     issue = repo.get_issue(issue_or_pr_number)
     issue.create_comment(comment_text)
+
+
+def add_emoji_to_comment(repo_name: str, comment_id: int, emoji_name: str) -> None:
+    """Adds an emoji reaction to a specified comment within a GitHub repository.
+
+    Args:
+            repo_name (str): The name of the repository containing the comment.
+            comment_id (int): The unique identifier for the comment to react to.
+            emoji_name (str): The name of the emoji to add as a reaction.
+
+    This function does not return a value.
+    """
+    api_key = os.environ["GITHUB_API_KEY"]
+    g = Github(api_key)
+    repo = g.get_repo(repo_name)
+    comment = repo.get_comment(comment_id)
+    comment.create_reaction(emoji_name)

--- a/src/test_repo.py
+++ b/src/test_repo.py
@@ -6,26 +6,24 @@ from repo import get_open_pr_comments, IssueComment
 class TestRepo(unittest.TestCase):
     @patch("repo.Github")
     def test_get_open_pr_comments(self, mock_github):
-        # Create a mock API response
         mock_comment = MagicMock()
         mock_comment.user.login = "username"
         mock_comment.body = "comment body"
         mock_pull = MagicMock()
         mock_pull.get_comments.return_value = [mock_comment]
-
-        # Mock the Github repository and get_pulls method
         mock_repo = mock_github.return_value.get_repo.return_value
         mock_repo.get_pulls.return_value = [mock_pull]
-
-        # Execute the function with the mock objects
         result = get_open_pr_comments("test/repo")
-
-        # Assertions
         self.assertIsInstance(result, list)
         self.assertTrue(all(isinstance(comment, IssueComment) for comment in result))
         for comment in result:
             self.assertEqual(comment.username, "username")
             self.assertEqual(comment.content, "comment body")
+
+    @patch("repo.add_emoji_to_comment")
+    def test_add_emoji_to_comment(self, mock_add_emoji):
+        add_emoji_to_comment("test/repo", 42, ":thumbs_up:")
+        mock_add_emoji.assert_called_once_with("test/repo", 42, ":thumbs_up:")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR addresses issue #1389. Title: Add function to emoji a comment
Description: In repo.py, add a function to give an emoji reaction to a comment on an Issue or PR.