### PR TITLE
Add function to emoji a comment

### DIFF
--- a/src/repo.py
+++ b/src/repo.py
@@ -447,3 +447,20 @@ def add_comment_to_issue_or_pr(
     repo = g.get_repo(repo_name)
     issue = repo.get_issue(issue_or_pr_number)
     issue.create_comment(comment_text)
+
+
+def add_emoji_reaction_to_comment(repo_name: str, comment_id: int, emoji: str) -> None:
+    """Gives an emoji reaction to a specific comment on an issue or pull request within a GitHub repository.
+
+    Args:
+        repo_name (str): The name of the repository containing the comment.
+        comment_id (int): The ID of the comment to react to.
+        emoji (str): The content of the emoji reaction.
+
+    This function does not return a value.
+    """
+    api_key = os.environ["GITHUB_API_KEY"]
+    g = Github(api_key)
+    repo = g.get_repo(repo_name)
+    comment = repo.get_comment(comment_id)
+    comment.create_reaction(emoji)

--- a/src/test_repo.py
+++ b/src/test_repo.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import patch, MagicMock
-from repo import get_open_pr_comments, IssueComment
+from repo import get_open_pr_comments, IssueComment, add_emoji_reaction_to_comment
 
 
 class TestRepo(unittest.TestCase):
@@ -26,6 +26,23 @@ class TestRepo(unittest.TestCase):
         for comment in result:
             self.assertEqual(comment.username, "username")
             self.assertEqual(comment.content, "comment body")
+
+    @patch("repo.Github")
+    def test_add_emoji_reaction_to_comment(self, mock_github):
+        # Create a mock API response
+        mock_comment = MagicMock()
+        emoji = "+1"
+
+        # Mock the Github repository and get_comment method
+        mock_repo = mock_github.return_value.get_repo.return_value
+        mock_repo.get_comment.return_value = mock_comment
+
+        # Execute the function with the mock objects
+        add_emoji_reaction_to_comment("test/repo", 42, emoji)
+
+        # Assertions
+        mock_repo.get_comment.assert_called_once_with(42)
+        mock_comment.create_reaction.assert_called_once_with(emoji)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR addresses issue #1389. Title: Add function to emoji a comment
Description: In repo.py, add a function to give an emoji reaction to a comment on an Issue or PR.