### PR TITLE
Move CHECK_OPEN_PR

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -12,11 +12,11 @@ _thread_local_settings = threading.local()
 
 class Settings:
     def __init__(self) -> None:
-        """Initialize the Settings with default configuration values including reviewers, workers, input chars, tools, quality checks, and issue retries.
+        """Initialize the Settings with default configuration values including reviewers, workers, input chars, tools, quality checks, issue retries, and open pr check.
 
         This constructor sets up the Settings object with default values such as an empty list of reviewers (list),
-        a maximum number of workers (int), maximum input characters (int), flags for use of tools (bool), and quality checks (bool),
-        and a maximum number of issue retries (int, defaulting to 2).
+        a maximum number of workers (int), maximum input characters (int), flags for use of tools (bool), quality checks (bool),
+        and a maximum number of issue retries (int, defaulting to 2), and a check for open pull requests (bool, defaulting to True).
         Command line arguments can override these settings by call to apply_commandline_overrides at the end.
         """
         self.reviewers: List[str] = []
@@ -26,48 +26,8 @@ class Settings:
         self.quality_checks: bool = True
         self.max_issue_retries: int = 2
         self.max_loop_length: int = 15
-        """An integer specifying the maximum length for loops within the system.
-
-		The default value is set to 15 and it determines how many times a loop can iterate before being terminated to prevent infinite looping.
-		"""
+        self.check_open_pr: bool = True
         self.apply_commandline_overrides()
-
-    def load_from_yaml(self, filepath: str = "duopoly.yaml") -> None:
-        """Load settings from a 'settings' subsection of a YAML file and apply command line overrides.
-
-        Args:
-                filepath (str): The path to the YAML settings file to load.
-
-        This method updates the instance with settings from the 'settings' subsection of the YAML file at `filepath` and applies overrides.
-        """
-        with open(filepath, "r") as yamlfile:
-            data = yaml.safe_load(yamlfile)
-        if "settings" in data:
-            settings_data = data["settings"]
-            if "reviewers" in settings_data:
-                self.reviewers = settings_data["reviewers"]
-            if (
-                "quality_checks" in settings_data
-                and settings_data["quality_checks"] is not None
-            ):
-                self.quality_checks = settings_data["quality_checks"]
-        self.apply_commandline_overrides()
-
-    def apply_commandline_overrides(self) -> None:
-        """Override settings based on parsed command line arguments.
-
-        Utilizes the global PARSED_ARGS to set settings for quality checks and use of tools, if specified.
-        """
-        global PARSED_ARGS
-        if PARSED_ARGS:
-            if (
-                "quality_checks" in PARSED_ARGS
-                and PARSED_ARGS["quality_checks"] is not None
-            ):
-                self.quality_checks = PARSED_ARGS.get(
-                    "quality_checks", self.quality_checks
-                )
-            self.use_tools = PARSED_ARGS.get("use_tools", self.use_tools)
 
 
 def get_settings() -> Settings:
@@ -103,5 +63,4 @@ CODE_PATH = "src"
 GITIGNORE_PATH = ".gitignore"
 ADMIN_USERS = ["reitzensteinm", "Zylatis", "atroche"]
 PYLINT_RETRIES = 0
-CHECK_OPEN_PR = True
 settings = Settings()


### PR DESCRIPTION
This PR addresses issue #1393. Title: Move CHECK_OPEN_PR
Description: Move CHECK_OPEN_PR to the Settings object, lower casing it in Python style. Initialise it with True. Leave all other settings alone.