### PR TITLE
Add a move_file_using_rope function

### DIFF
--- a/src/tools/move_file.py
+++ b/src/tools/move_file.py
@@ -1,5 +1,8 @@
 import copy
 import settings
+from rope.base.project import Project
+from rope.base.libutils import path_to_resource
+from rope.refactor.move import create_move
 
 
 def move_file(file_mapping, old_path, new_path):
@@ -37,3 +40,25 @@ def fix_imports(file_string, old_namespace, new_namespace):
         if "import" in line:
             lines[i] = line.replace(old_namespace, new_namespace)
     return "\n".join(lines)
+
+
+def move_file_using_rope(
+    project_directory: str, relative_from_path: str, relative_to_path: str
+) -> None:
+    """
+    Moves a file from one location to another within a project using the rope library.
+
+    - `project_directory`: The path to the project directory where the move will occur.
+    - `relative_from_path`: The relative path from the project directory of the file to be moved.
+    - `relative_to_path`: The relative path to where the file should be moved.
+
+    Returns None. The move is performed on the file system using the rope library's functionality.
+    """
+    project = Project(project_directory)
+    resource_from = path_to_resource(project, relative_from_path)
+    resource_to = path_to_resource(project, relative_to_path)
+
+    move = create_move(project, resource_from, resource_to)
+    move.do()
+
+    project.close()


### PR DESCRIPTION
This PR addresses issue #1390. Title: Add a move_file_using_rope function
Description: Take a project directory, as well as a relative from and a relative to path. 

Add it to move_file.py. Use the rope library, with its rename functionality, treating files as resources.