### PR TITLE
Add a move_file_using_rope function

### DIFF
--- a/src/tools/move_file.py
+++ b/src/tools/move_file.py
@@ -1,5 +1,7 @@
 import copy
 import settings
+from rope.base.project import Project
+from rope.refactor.rename import Rename
 
 
 def move_file(file_mapping, old_path, new_path):
@@ -37,3 +39,27 @@ def fix_imports(file_string, old_namespace, new_namespace):
         if "import" in line:
             lines[i] = line.replace(old_namespace, new_namespace)
     return "\n".join(lines)
+
+
+def move_file_using_rope(project_directory: str, from_path: str, to_path: str) -> None:
+    """
+    Move a file within a project directory from one path to another using rope's Rename tool.
+
+    This function takes a project directory and relative 'from' and 'to' paths, uses the rope library's Rename tool
+    to create a changeset for renaming the file on disk, and applies this changeset using project.do(changes).
+
+    Args:
+            project_directory: The directory of the project where the file is located.
+            from_path: The relative path of the file to move.
+            to_path: The relative path to move the file to.
+
+    Returns:
+            None
+    """
+    project = Project(project_directory)
+    resource = project.get_file(from_path)
+    renamer = Rename(project, resource)
+    changes = renamer.get_changes(new_name=to_path)
+    project.do(changes)
+    project.validate()
+    project.commit()


### PR DESCRIPTION
This PR addresses issue #1390. Title: Add a move_file_using_rope function
Description: Take a project directory, as well as a relative from and a relative to path. 

Add it to move_file.py. 

You must the rope library's Rename tool, under rope.refactor.rename, using the file as a resource. In Rope, Rename on a file renames the file on disk. Rope's Move command is not intended to move files.

After you have a changeset, project.do(changes) will run it.