### PR TITLE
Add a move_file_using_rope function

### DIFF
--- a/src/tools/move_file.py
+++ b/src/tools/move_file.py
@@ -1,5 +1,7 @@
 import copy
 import settings
+from rope.base.project import Project
+from rope.refactor.rename import Rename
 
 
 def move_file(file_mapping, old_path, new_path):
@@ -37,3 +39,24 @@ def fix_imports(file_string, old_namespace, new_namespace):
         if "import" in line:
             lines[i] = line.replace(old_namespace, new_namespace)
     return "\n".join(lines)
+
+
+def move_file_using_rope(project_directory: str, from_path: str, to_path: str) -> None:
+    """Rename a file in a project using the rope library's Rename tool.
+
+    :param project_directory: The directory of the project containing the file.
+    :param from_path: The relative path to the file in the project to be moved.
+    :param to_path: The relative path to the destination in the project.
+    """
+    # Initialize the Rope project
+    project = Project(project_directory)
+
+    # Initialize the Rename refactoring with the file to be moved as a resource
+    resource = project.get_resource(from_path)
+    renamer = Rename(project, resource)
+
+    # Prepare changeset
+    changeset = renamer.get_changes(newname=to_path)
+
+    # Apply changes
+    project.do(changeset)


### PR DESCRIPTION
This PR addresses issue #1390. Title: Add a move_file_using_rope function
Description: Take a project directory, as well as a relative from and a relative to path. 

Add it to move_file.py. 

You must the rope library's Rename tool, under rope.refactor.rename, using the file as a resource. In Rope, Rename on a file renames the file on disk. Rope's Move command is not intended to move files.

After you have a changeset, project.do(changes) will run it.