### PR TITLE
Add a move_file_using_rope function

### DIFF
--- a/src/tools/move_file.py
+++ b/src/tools/move_file.py
@@ -1,5 +1,7 @@
 import copy
 import settings
+from rope.base import project as rope_project
+from rope.refactor.rename import Rename
 
 
 def move_file(file_mapping, old_path, new_path):
@@ -25,15 +27,55 @@ def move_file(file_mapping, old_path, new_path):
     return file_mapping_copy
 
 
-def path_to_namespace(file_path):
+def path_to_namespace(file_path: str) -> str:
+    """
+    Convert a file path to a Python namespace by stripping the code path prefix and replacing slashes with dots.
+
+    Arguments:
+    file_path: The file path to convert.
+    Returns:
+    The converted namespace as a string.
+    """
     if file_path.startswith(settings.CODE_PATH + "/") and file_path.endswith(".py"):
         file_path = file_path[len(settings.CODE_PATH) + 1 : -3]
     return file_path.replace("/", ".")
 
 
-def fix_imports(file_string, old_namespace, new_namespace):
+def fix_imports(file_string: str, old_namespace: str, new_namespace: str) -> str:
+    """
+    Update the import statements in the provided file content from the old namespace to the new namespace.
+
+    Arguments:
+    file_string: The content of the file as a string.
+    old_namespace: The old namespace to be replaced.
+    new_namespace: The new namespace to replace with.
+    Returns:
+    The updated content of the file as a string.
+    """
     lines = file_string.split("\n")
     for i, line in enumerate(lines):
         if "import" in line:
             lines[i] = line.replace(old_namespace, new_namespace)
     return "\n".join(lines)
+
+
+def move_file_using_rope(
+    project_dir: str, from_rel_path: str, to_rel_path: str
+) -> None:
+    """
+    Moves a file from one path to another within a given project directory using the rope library's Rename refactoring tool.
+
+    This function will create a rope project, use the Rename refactoring tool to rename the file and apply the changes to the filesystem.
+    Arguments:
+    project_dir: The path to the project directory.
+    from_rel_path: The current relative path of the file to be moved.
+    to_rel_path: The new relative path for the file after moving.
+    Returns:
+    None
+    """
+    proj = rope_project.Project(project_dir)
+    resource = proj.get_file(from_rel_path)
+    renamer = Rename(proj, resource)
+    to_file_name = to_rel_path.split("/")[-1]
+    changes = renamer.get_changes(to_file_name)
+    proj.do(changes)


### PR DESCRIPTION
This PR addresses issue #1390. Title: Add a move_file_using_rope function
Description: Take a project directory, as well as a relative from and a relative to path. 

Add it to move_file.py. 

You must the rope library's Rename tool, under rope.refactor.rename, using the file as a resource. In Rope, Rename on a file renames the file on disk. Rope's Move command is not intended to move files.

After you have a changeset, project.do(changes) will run it.