### PR TITLE
Add packages & terminal to features

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ the [second commit](https://github.com/reitzensteinm/duopoly/commit/7646e1be5a28
 - [x] Quality steps, including feedback from reflection, PyTest, PyLint and MyPy
 - [x] Parallel execution
 - [x] HTML Report Generation
+- [x] Install packages and execute terminal commands
 - [ ] Respond to PR feedback
 - [ ] Evals framework to track performance over time
 - [ ] Precalculated code summarization for Retrieval Augmented Generation


### PR DESCRIPTION
This PR addresses issue #1434. Title: Add packages & terminal to features
Description: Add "Install packages and execute terminal commands" as a ticked feature to the features list in readme.md, underneath the HTML Report Generation line.