### PR TITLE
Don't skip generation if a draft PR has been created

### DIFF
--- a/src/pipeline/issue.py
+++ b/src/pipeline/issue.py
@@ -117,8 +117,7 @@ def process_directory(prompt: str, project: Project) -> None:
             pylint_result = run_pylint(os.path.join(project.path, "src"))
             if pylint_result is not None and iteration < PYLINT_RETRIES:
                 apply_prompt_to_directory(
-                    f"Fix these errors identified by PyLint:\n{pylint_result}",
-                    project,
+                    f"Fix these errors identified by PyLint:\n{pylint_result}", project
                 )
             elif pylint_result is not None and iteration == PYLINT_RETRIES:
                 raise QualityException("Pylint failed\n" + pylint_result)
@@ -165,7 +164,7 @@ def prepare_branch(issue: Issue, dry_run: bool) -> Project:
 def process_issue(issue: Issue, dry_run: bool) -> None:
     """Processes a single issue by setting up a branch, applying prompts, running checks, and creating pull requests.
 
-    The function checks the retry count, and skips processing if max retries are exceeded, if the author is not an admin, the issue is not open, or if there is an open PR for the issue.
+    The function checks the retry count, and skips processing if max retries are exceeded, if the author is not an admin, the issue is not open, or if there is an open non-draft PR for the issue.
 
     Params:
             issue (Issue): The issue to be processed.
@@ -182,7 +181,9 @@ def process_issue(issue: Issue, dry_run: bool) -> None:
     settings_instance = settings.get_settings()
     if (
         settings_instance.check_open_pr
-        and repo.check_issue_has_open_pr_with_same_title(issue.repository, issue.title)
+        and repo.check_issue_has_open_pr_with_same_title(
+            issue.repository, issue.title, consider_drafts=False
+        )
     ):
         return
     issue_state = IssueState.retrieve_by_id(issue.id)

--- a/src/pipeline/issue_state.py
+++ b/src/pipeline/issue_state.py
@@ -6,21 +6,21 @@ class IssueState:
     """Represents the state of an issue with a retry count, an associated prompt, a record of initial file states, and an optional PR ID.
 
     Args:
-            id (int): The identifier of the issue.
+                    id (int): The identifier of the issue.
 
     Returns:
-            IssueState: An instance representing the issue state.
+                    IssueState: An instance representing the issue state.
 
     Attributes:
-            initial_files (Optional[Dict[str, str]]): A mapping of filenames to their contents representing initial file states, or None if there are no initial files.
-            pr_id (Optional[int]): The identifier of the associated pull request, if any.
+                    initial_files (Optional[Dict[str, str]]): A mapping of filenames to their contents representing initial file states, or None if there are no initial files.
+                    pr_id (Optional[int]): The identifier of the associated pull request, if any.
     """
 
     def __init__(self, id: int):
         """Initialize the IssueState with an ID, a retry count set to zero, an empty prompt, no initial files, and no associated PR ID.
 
         Args:
-                id (int): The identifier of the issue.
+                        id (int): The identifier of the issue.
 
         """
         self.id = id
@@ -34,10 +34,10 @@ class IssueState:
         """Retrieve the issue state by id directly if it exists, or create and store a new one if not found.
 
         Args:
-                id (int): The identifier of the issue.
+                        id (int): The identifier of the issue.
 
         Returns:
-                IssueState: The retrieved or newly created issue state.
+                        IssueState: The retrieved or newly created issue state.
         """
         try:
             return read(f"issue-{id}")
@@ -50,7 +50,7 @@ class IssueState:
         """Store the current issue state.
 
         Returns:
-                None
+                        None
         """
         write(f"issue-{self.id}", self)
 
@@ -58,6 +58,6 @@ class IssueState:
         """Return a string representation of the issue state.
 
         Returns:
-                str: The string representation of the issue state.
+                        str: The string representation of the issue state.
         """
         return str(self.__dict__)


### PR DESCRIPTION
This PR addresses issue #1445. Title: Don't skip generation if a draft PR has been created
Description: Add a default parameter to check_issue_has_open_pr_with_same_title for whether to consider draft PRs (default to True).

In process_issue, when checking if a PR exists in order to skip processing, don't check for draft PRs.