### PR TITLE
Bump package versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.9.1
+aiohttp==3.9.5
 aiosignal==1.3.1
 annotated-types==0.6.0
 anyio==3.7.1
@@ -14,7 +14,7 @@ charset-normalizer==3.1.0
 click==8.1.3
 colorama==0.4.6
 coverage==7.3.2
-cryptography==41.0.7
+cryptography==42.0.7
 Deprecated==1.2.13
 dill==0.3.6
 distro==1.8.0
@@ -22,14 +22,14 @@ exceptiongroup==1.1.1
 frozenlist==1.3.3
 git-fame==2.0.1
 gitdb==4.0.10
-GitPython==3.1.40
+GitPython==3.1.43
 h11==0.14.0
 httpcore==1.0.1
 httpx==0.25.1
 idna==3.4
 iniconfig==2.0.0
 isort==5.12.0
-Jinja2==3.1.2
+Jinja2==3.1.4
 lazy-object-proxy==1.9.0
 MarkupSafe==2.1.3
 mccabe==0.7.0
@@ -37,7 +37,7 @@ multidict==6.0.4
 mypy==1.4.1
 mypy-extensions==1.0.0
 numpy==1.25.1
-openai==1.2.4
+openai==1.31.0
 packaging==23.1
 pathspec==0.11.1
 platformdirs==3.5.1
@@ -53,7 +53,7 @@ pytest==7.3.1
 pytest-cov==4.1.0
 pytoolconfig==1.2.6
 PyYAML==6.0.1
-requests==2.31.0
+requests==2.32.3
 rope==1.11.0
 ruff==0.1.6
 smmap==5.0.0
@@ -63,7 +63,7 @@ termcolor==2.3.0
 tomli==2.0.1
 tomlkit==0.11.8
 tqdm==4.65.0
-typing_extensions==4.6.3
+typing_extensions==4.12.1
 urllib3==2.1.0
 wrapt==1.15.0
 yarl==1.9.2


### PR DESCRIPTION
This PR addresses issue #1451. Title: Bump package versions
Description: Update to the latest: 

aiohttp
cryptography
GitPython
requqests
Jinja2
aiohttp