### PR TITLE
Write HTML traces as UTF-8

### DIFF
--- a/src/tracing/test_trace.py
+++ b/src/tracing/test_trace.py
@@ -1,0 +1,38 @@
+import unittest
+import os
+from trace import Trace
+
+
+class TestTrace(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.trace = Trace("test_trace")
+        self.trace_file = f"traces/{self.trace.name}.html"
+        if not os.path.exists("traces"):
+            os.mkdir("traces")
+
+    def test_add_trace_data_utf8_encoding(self) -> None:
+        """Test that add_trace_data writes a trace with UTF-8 encoding."""
+        test_html_content = "<div>Test Trace Content</div>"
+        self.trace.add_trace_data("test_tag", test_html_content)
+
+        self.assertTrue(os.path.exists(self.trace_file))
+
+        with open(self.trace_file, "rb") as file:
+            content_bytes = file.read()
+
+        try:
+            content = content_bytes.decode("utf-8")
+            self.assertEqual(content, test_html_content)
+        except UnicodeDecodeError:
+            self.fail("The trace file is not encoded with UTF-8")
+
+    def tearDown(self) -> None:
+        if os.path.exists(self.trace_file):
+            os.remove(self.trace_file)
+        if os.path.exists("traces"):
+            os.rmdir("traces")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tracing/trace.py
+++ b/src/tracing/trace.py
@@ -15,6 +15,7 @@ class TraceData:
 
 
 class Trace:
+
     def __init__(self, name: str):
         from datetime import datetime
 
@@ -22,13 +23,24 @@ class Trace:
         self.name = f"{current_time}_{name}"
         self.trace_data = []
 
-    def add_trace_data(self, tag, trace, tokens: Optional[Tuple[int, int]] = None):
+    def add_trace_data(
+        self, tag: str, trace: str, tokens: Optional[Tuple[int, int]] = None
+    ) -> None:
+        """
+        Add trace data with the given tag, trace, and optional tokens to the trace.
+        Args:
+                tag: The tag associated with the trace data.
+                trace: The HTML trace to be written.
+                tokens: An optional tuple indicating the start and end tokens.
+        Returns:
+                None
+        """
         if self.name == "":
             return
         self.trace_data.append(TraceData(tag, trace, tokens))
         html_trace = render_trace(self)
         os.makedirs("traces", exist_ok=True)
-        with open(f"traces/{self.name}.html", "w") as f:
+        with open(f"traces/{self.name}.html", "w", encoding="utf-8") as f:
             f.write(html_trace)
 
 


### PR DESCRIPTION
This PR addresses issue #1457. Title: Write HTML traces as UTF-8
Description: In add_trace_data, encode HTML traces as UTF-8