### PR TITLE
Generate PowerShell equivalent of run.sh

### DIFF
--- a/run.ps1
+++ b/run.ps1
@@ -1,0 +1,52 @@
+#Requires -Version 3.0
+
+# Default to the main branch if no version is specified
+$version = "main"
+# Initialize an empty array for additional arguments
+$extra_args = @()
+
+# Iterate over arguments to find a version and collect additional arguments
+foreach ($arg in $args) {
+	if ($arg -eq "--version") {
+		$expect_version_val = $true
+	}
+	elseif ($expect_version_val) {
+		$version = $arg
+		$expect_version_val = $false
+	}
+	else {
+		$extra_args += $arg
+	}
+}
+
+# Checkout to the specified version or main if version is not set
+git checkout $version
+Write-Host "Checked out to $version"
+
+# Check if the traces/ directory already exists
+if (Test-Path -Path "traces/") {
+	Write-Host "The traces/ directory already exists."
+}
+else {
+	# Create a new traces/ directory
+	mkdir traces/
+}
+
+# Run a python web server on port 8000 in the background
+Start-Job { python -m http.server -d traces/ 8000 }
+
+while ($true) {
+	# Update git repo
+	git pull
+
+	# Install requirements
+	pip install -q -r requirements.txt
+
+	# Run the python script with additional arguments
+	python src/main.py $extra_args
+
+	Write-Host "Execution successful" -ForegroundColor Magenta
+
+	# Sleep for 20 seconds
+	Start-Sleep -Seconds 20
+}


### PR DESCRIPTION
This PR addresses issue #1460. Title: Generate PowerShell equivalent of run.sh
Description: Create a run.ps1 script in the same directory as run.sh, and copy the functionality across. Keep run.sh as is. Variation in behaviour is acceptable if there are differences per platform.