### PR TITLE
Use tools by default

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -22,7 +22,7 @@ class Settings:
         self.reviewers: List[str] = []
         self.max_workers: int = 10
         self.max_input_chars: int = 48000
-        self.use_tools: bool = False
+        self.use_tools: bool = True
         self.quality_checks: bool = True
         self.max_issue_retries: int = 2
         self.max_loop_length: int = 15


### PR DESCRIPTION
This PR addresses issue #1483. Title: Use tools by default
Description: In settings.py, set the use_tools field to True by default, and leave the rest of the file exactly as it was. Do not leave anything out.