### PR TITLE
Refactor ADMIN_USERS

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -12,11 +12,12 @@ _thread_local_settings = threading.local()
 
 class Settings:
     def __init__(self) -> None:
-        """Initialize the Settings with default configuration values including reviewers, workers, input chars, tools, quality checks, issue retries, and check for open PRs.
+        """Initialize the Settings with default configuration values including reviewers, workers, input chars, tools, quality checks, issue retries, check for open PRs and admin users.
 
         This constructor sets up the Settings object with default values such as an empty list of reviewers (list),
         a maximum number of workers (int), maximum input characters (int), flags for use of tools (bool), quality checks (bool),
-        a maximum number of issue retries (int, defaulting to 2), and a boolean to check for open PRs (bool), defaulting to True.
+        a maximum number of issue retries (int, defaulting to 2), a boolean to check for open PRs (bool), defaulting to True,
+        and a list of admin users (list).
         Command line arguments can override these settings by call to apply_commandline_overrides at the end.
         """
         self.reviewers: List[str] = []
@@ -31,13 +32,18 @@ class Settings:
 
 		The default value is set to True to enable checking of open pull requests by default.
 		"""
+        self.admin_users: List[str] = ["reitzensteinm", "Zylatis", "atroche"]
+        """A list of admin users.
+
+		The default value includes 'reitzensteinm', 'Zylatis', and 'atroche'.
+		"""
         self.apply_commandline_overrides()
 
     def load_from_yaml(self, filepath: str = "duopoly.yaml") -> None:
         """Load settings from a 'settings' subsection of a YAML file and apply command line overrides.
 
         Args:
-                filepath (str): The path to the YAML settings file to load.
+                        filepath (str): The path to the YAML settings file to load.
 
         This method updates the instance with settings from the 'settings' subsection of the YAML file at `filepath` and applies overrides.
         """
@@ -82,7 +88,7 @@ def get_settings() -> Settings:
     """Retrieve the current thread-local Settings instance or the global instance if not set.
 
     Returns:
-        Settings: The current thread-local Settings instance or the global Settings instance.
+            Settings: The current thread-local Settings instance or the global Settings instance.
 
     This function fetches the Settings object associated with the thread-local storage.
     If it does not exist, it returns the global Settings instance.
@@ -96,7 +102,7 @@ def apply_settings(yaml_path: str) -> None:
     """Create a new Settings instance from a YAML file and store it in thread-local storage.
 
     Args:
-        yaml_path (str): The path to the YAML file from which to load settings.
+            yaml_path (str): The path to the YAML file from which to load settings.
 
     This function creates a new Settings instance, loads settings from the specified YAML file,
     and stores it in the thread-local storage.
@@ -109,6 +115,5 @@ def apply_settings(yaml_path: str) -> None:
 REPOSITORY_PATH = ["reitzensteinm/duopoly", "reitzensteinm/duopoly-website"]
 CODE_PATH = "src"
 GITIGNORE_PATH = ".gitignore"
-ADMIN_USERS = ["reitzensteinm", "Zylatis", "atroche"]
 PYLINT_RETRIES = 0
 settings = Settings()


### PR DESCRIPTION
This PR addresses issue #1505. Title: Refactor ADMIN_USERS
Description: Copy the ADMIN_USERS constant in settings.py to an admin_users field on the Settings object. 