### PR TITLE
Use the admin_users field on Settings instead of the constant

### DIFF
--- a/src/pipeline/issue.py
+++ b/src/pipeline/issue.py
@@ -117,8 +117,7 @@ def process_directory(prompt: str, project: Project) -> None:
             pylint_result = run_pylint(os.path.join(project.path, "src"))
             if pylint_result is not None and iteration < PYLINT_RETRIES:
                 apply_prompt_to_directory(
-                    f"Fix these errors identified by PyLint:\n{pylint_result}",
-                    project,
+                    f"Fix these errors identified by PyLint:\n{pylint_result}", project
                 )
             elif pylint_result is not None and iteration == PYLINT_RETRIES:
                 raise QualityException("Pylint failed\n" + pylint_result)
@@ -175,11 +174,11 @@ def process_issue(issue: Issue, dry_run: bool) -> None:
             None
     """
     is_quality_exception = False
-    if issue.author not in settings.ADMIN_USERS:
+    settings_instance = settings.get_settings()
+    if issue.author not in settings_instance.admin_users:
         return
     if not repo.is_issue_open(issue.repository, issue.number):
         return
-    settings_instance = settings.get_settings()
     if (
         settings_instance.check_open_pr
         and repo.check_issue_has_open_pr_with_same_title(issue.repository, issue.title)

--- a/src/settings.py
+++ b/src/settings.py
@@ -29,10 +29,10 @@ class Settings:
         self.max_loop_length: int = 15
         self.check_open_pr: bool = True
         """A boolean indicating if the system should check for open pull requests.
-
+		
 		The default value is set to True to enable checking of open pull requests by default.
 		"""
-        self.admin_users: List[str] = ADMIN_USERS
+        self.admin_users: List[str] = []
         self.apply_commandline_overrides()
 
     def load_from_yaml(self, filepath: str = "duopoly.yaml") -> None:
@@ -111,6 +111,5 @@ def apply_settings(yaml_path: str) -> None:
 REPOSITORY_PATH = ["reitzensteinm/duopoly", "reitzensteinm/duopoly-website"]
 CODE_PATH = "src"
 GITIGNORE_PATH = ".gitignore"
-ADMIN_USERS = ["reitzensteinm", "Zylatis", "atroche"]
 PYLINT_RETRIES = 0
 settings = Settings()


### PR DESCRIPTION
This PR addresses issue #1508. Title: Use the admin_users field on Settings instead of the constant
Description: Replace uses of the ADMIN_USERS constant with the field on the Settings object, accessed via get_settings()